### PR TITLE
Add `default_record` method to `ContextLogger`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v16
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.2] - 2025.05.14
+
+- Added `default_record` method to `ContextLogger` that allows setting default
+  records which will be included in all log entries regardless of context
+
 ## [0.1.1] - 2025.05.14
 
 - Fixed `ContextLogger::try_init` method where the wrong object was being passed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/crate/context-logger"
 repository = "https://github.com/alekseysidorov/context-logger"
 
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.85"
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ fn main() {
     let env_logger = env_logger::builder().build();
     let max_level = env_logger.filter();
     // Wrap it with ContextLogger to enable context propagation.
-    let context_logger = ContextLogger::new(env_logger);
+    let context_logger = ContextLogger::new(env_logger)
+        // Add version default record.
+        .default_record("version", "1.0.0");
     // Initialize the resulting logger.
     context_logger.init(max_level);   
 
@@ -53,7 +55,7 @@ fn main() {
     let _guard = ctx.enter();
     
     // Log with context automatically attached
-    info!("Processing request"); // Will include request_id=req-123 and user_id=42
+    info!("Processing request"); // Will include version=1.0.0 request_id=req-123 and user_id=42
 }
 ```
 

--- a/examples/contexted_log_async.rs
+++ b/examples/contexted_log_async.rs
@@ -16,7 +16,7 @@ fn try_init_logger() -> Result<(), Box<dyn std::error::Error>> {
         .with_target_writer("*", structured_logger::json::new_writer(std::io::stdout()))
         .build();
     ContextLogger::new(logger)
-        .with_default_record("instance", "contexted_log_async")
+        .default_record("instance", "contexted_log_async")
         .try_init(level)?;
 
     Ok(())

--- a/examples/contexted_log_async.rs
+++ b/examples/contexted_log_async.rs
@@ -13,13 +13,11 @@ fn try_init_logger() -> Result<(), Box<dyn std::error::Error>> {
     let level = log::LevelFilter::Info;
 
     let logger = structured_logger::Builder::with_level(level.as_str())
-        .with_target_writer(
-            "*",
-            structured_logger::async_json::new_writer(tokio::io::stdout()),
-        )
+        .with_target_writer("*", structured_logger::json::new_writer(std::io::stdout()))
         .build();
-    let context_logger = ContextLogger::new(logger);
-    context_logger.try_init(level)?;
+    ContextLogger::new(logger)
+        .with_default_record("instance", "contexted_log_async")
+        .try_init(level)?;
 
     Ok(())
 }

--- a/examples/contexted_log_sync.rs
+++ b/examples/contexted_log_sync.rs
@@ -13,8 +13,9 @@ fn try_init_logger() -> Result<(), Box<dyn std::error::Error>> {
         .build();
     let level = env_logger.filter();
 
-    let context_logger = ContextLogger::new(env_logger);
-    context_logger.try_init(level)?;
+    ContextLogger::new(env_logger)
+        .with_default_record("instance", "contexted_log_sync")
+        .try_init(level)?;
 
     Ok(())
 }

--- a/examples/contexted_log_sync.rs
+++ b/examples/contexted_log_sync.rs
@@ -14,7 +14,7 @@ fn try_init_logger() -> Result<(), Box<dyn std::error::Error>> {
     let level = env_logger.filter();
 
     ContextLogger::new(env_logger)
-        .with_default_record("instance", "contexted_log_sync")
+        .default_record("instance", "contexted_log_sync")
         .try_init(level)?;
 
     Ok(())

--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1746081462,
-        "narHash": "sha256-WmJBaktb33WwqNn5BwdJghAoiBnvnPhgHSBksTrF5K8=",
+        "lastModified": 1754030776,
+        "narHash": "sha256-EA7Qh5OUc3tgYrLHfG7zU6wxltvWsJ0+sFxOcVsbjOY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e3be528e4f03538852ba49b413ec4ac843edeb60",
+        "rev": "451f184de2958f8e725acba046ec10670dd771a1",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747610100,
-        "narHash": "sha256-rpR5ZPMkWzcnCcYYo3lScqfuzEw5Uyfh+R0EKZfroAc=",
+        "lastModified": 1756217674,
+        "narHash": "sha256-TH1SfSP523QI7kcPiNtMAEuwZR3Jdz0MCDXPs7TS8uo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca49c4304acf0973078db0a9d200fd2bae75676d",
+        "rev": "4e7667a90c167f7a81d906e5a75cba4ad8bee620",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1745377448,
-        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1746024678,
-        "narHash": "sha256-Q5J7+RoTPH4zPeu0Ka7iSXtXty228zKjS0Ed4R+ohpA=",
+        "lastModified": 1753974682,
+        "narHash": "sha256-Ya4Ecj8JaKkapgYCCybzZBcypXpblhuG0hVDzdy2zyo=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5d66d45005fef79751294419ab9a9fa304dfdf5c",
+        "rev": "68e7ec90bf29c9b17d0dcdb3358de5dee7f4afb5",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1747469671,
-        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
+        "lastModified": 1755934250,
+        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
+        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,10 +40,6 @@
         openssl
         pkg-config
         jq
-      ]
-      # Some additional libraries for the Darwin platform
-      ++ lib.optionals stdenv.isDarwin [
-        darwin.apple_sdk.frameworks.SystemConfiguration
       ];
 
       # Eval the treefmt modules from ./treefmt.nix

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@
 use crate::{
     ContextValue, StaticCowStr,
     guard::LogContextGuard,
-    stack::{CONTEXT_STACK, ContextProperties},
+    stack::{CONTEXT_STACK, ContextRecords},
 };
 
 /// A contextual properties that can be attached to log records.
@@ -11,13 +11,13 @@ use crate::{
 /// [`LogContext`] represents a set of key-value pairs that will be
 /// automatically added to log messages when the context is active.
 #[derive(Debug)]
-pub struct LogContext(pub(crate) ContextProperties);
+pub struct LogContext(pub(crate) ContextRecords);
 
 impl LogContext {
     /// Creates a new, empty context.
     #[must_use]
     pub const fn new() -> Self {
-        Self(ContextProperties::new())
+        Self(ContextRecords::new())
     }
 
     /// Adds property to this context.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 
 use std::borrow::Cow;
 
+use stack::ContextRecords;
+
 use self::stack::CONTEXT_STACK;
 pub use self::{context::LogContext, future::FutureExt, value::ContextValue};
 
@@ -72,6 +74,7 @@ type StaticCowStr = Cow<'static, str>;
 ///
 /// See [`LogContext`] for more information on how to create and manage context properties.
 pub struct ContextLogger {
+    default_records: ContextRecords,
     inner: Box<dyn log::Log>,
 }
 
@@ -85,6 +88,7 @@ impl ContextLogger {
         L: log::Log + 'static,
     {
         Self {
+            default_records: ContextRecords::new(),
             inner: Box::new(inner),
         }
     }
@@ -112,6 +116,25 @@ impl ContextLogger {
         log::set_max_level(max_level);
         log::set_boxed_logger(Box::new(self))
     }
+
+    /// Adds a default record that will be included in all log entries.
+    ///
+    /// Default records are automatically added to all log entries, regardless of
+    /// the current context. They are defined when the logger is created and remain
+    /// constant throughout the application's lifetime.
+    ///
+    /// # Note
+    ///
+    /// [`LogContext`] records take precedence over default records. If a key in the context has the same name as a default record, the context value will override the default value.
+    #[must_use]
+    pub fn with_default_record(
+        mut self,
+        key: impl Into<StaticCowStr>,
+        value: impl Into<ContextValue>,
+    ) -> Self {
+        self.default_records.push((key.into(), value.into()));
+        self
+    }
 }
 
 impl std::fmt::Debug for ContextLogger {
@@ -128,11 +151,12 @@ impl log::Log for ContextLogger {
     fn log(&self, record: &log::Record) {
         let error = CONTEXT_STACK.try_with(|stack| {
             if let Some(top) = stack.top() {
-                let extra_properties = ExtraProperties {
+                let extra_records = ExtraRecords {
                     source: &record.key_values(),
-                    properties: &*top,
+                    default_records: self.default_records.as_slice(),
+                    context_records: top.as_slice(),
                 };
-                let new_record = record.to_builder().key_values(&extra_properties).build();
+                let new_record = record.to_builder().key_values(&extra_records).build();
 
                 self.inner.log(&new_record);
             } else {
@@ -154,12 +178,13 @@ impl log::Log for ContextLogger {
     }
 }
 
-struct ExtraProperties<'a, I> {
+struct ExtraRecords<'a, I> {
     source: &'a dyn log::kv::Source,
-    properties: I,
+    default_records: I,
+    context_records: I,
 }
 
-impl<'a, I> log::kv::Source for ExtraProperties<'a, I>
+impl<'a, I> log::kv::Source for ExtraRecords<'a, I>
 where
     I: IntoIterator<Item = &'a (StaticCowStr, ContextValue)> + Copy,
 {
@@ -167,7 +192,11 @@ where
         &'kvs self,
         visitor: &mut dyn log::kv::VisitSource<'kvs>,
     ) -> Result<(), log::kv::Error> {
-        for (key, value) in self.properties {
+        // FIXME It's too tricky to chain iterators here without cloning the iterator.
+        for (key, value) in self.default_records {
+            visitor.visit_pair(log::kv::Key::from_str(key), value.as_log_value())?;
+        }
+        for (key, value) in self.context_records {
             visitor.visit_pair(log::kv::Key::from_str(key), value.as_log_value())?;
         }
         self.source.visit(visitor)

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -15,12 +15,12 @@ thread_local! {
     pub static CONTEXT_STACK: ContextStack = const { ContextStack::new() };
 }
 
-pub type ContextProperties = Vec<(StaticCowStr, ContextValue)>;
+pub type ContextRecords = Vec<(StaticCowStr, ContextValue)>;
 
 /// A stack of context properties.
 #[derive(Debug)]
 pub struct ContextStack {
-    inner: RefCell<Vec<ContextProperties>>,
+    inner: RefCell<Vec<ContextRecords>>,
 }
 
 impl ContextStack {
@@ -36,8 +36,8 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already borrowed.
-    pub fn push(&self, properties: ContextProperties) {
-        self.inner.borrow_mut().push(properties);
+    pub fn push(&self, records: ContextRecords) {
+        self.inner.borrow_mut().push(records);
     }
 
     /// Pops the top set of context properties from the stack.
@@ -45,7 +45,7 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already borrowed.
-    pub fn pop(&self) -> Option<ContextProperties> {
+    pub fn pop(&self) -> Option<ContextRecords> {
         self.inner.borrow_mut().pop()
     }
 
@@ -54,7 +54,7 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already mutably borrowed.
-    pub fn top(&self) -> Option<Ref<ContextProperties>> {
+    pub fn top(&self) -> Option<Ref<ContextRecords>> {
         let inner = self.inner.borrow();
         if inner.is_empty() {
             None
@@ -68,7 +68,7 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already borrowed.
-    pub fn top_mut(&self) -> Option<RefMut<ContextProperties>> {
+    pub fn top_mut(&self) -> Option<RefMut<ContextRecords>> {
         let inner = self.inner.borrow_mut();
         if inner.is_empty() {
             None


### PR DESCRIPTION
Added `default_record` method to `ContextLogger` that allows setting default records which will be included in all log entries regardless of context