### PR TITLE
Refactor: Introduce ScopeFrame for better context encapsulation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
         "type": "github"
       },
       "original": {

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ use crate::{
     stack::{SCOPE_STACK, ScopeFrame},
 };
 
-/// A contextual properties that can be attached to log records.
+/// A set of records that can be attached to a logging scope.
 ///
 /// [`LogContext`] represents a set of key-value pairs that will be
 /// automatically added to log messages when the context is active.
@@ -26,7 +26,7 @@ impl LogContext {
         }
     }
 
-    /// Adds property to this context.
+    /// Adds a record to this scope.
     ///
     /// # Examples
     ///
@@ -45,10 +45,10 @@ impl LogContext {
         self
     }
 
-    /// Adds property to the current active context.
+    /// Adds a record to the currently active scope.
     ///
-    /// This is useful for adding context information dynamically without having
-    /// direct access to the context.
+    /// This is useful for adding records dynamically without having
+    /// direct access to the current scope.
     ///
     /// # Note
     ///
@@ -61,7 +61,7 @@ impl LogContext {
     /// use log::info;
     ///
     /// fn process_request() {
-    ///     // Add context information dynamically
+    ///     // Add a record to the current scope dynamically
     ///     LogContext::add_record("processing_time_ms", 42);
     ///     info!("Request processed");
     /// }
@@ -82,7 +82,7 @@ impl LogContext {
         });
     }
 
-    /// Activating this context, returning a guard that will exit the context when dropped.
+    /// Activates this scope, returning a guard that will exit the scope when dropped.
     ///
     /// # In Asynchronous Code
     ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use crate::{
     LogValue,
     guard::LogContextGuard,
-    stack::{CONTEXT_STACK, ScopeFrame},
+    stack::{SCOPE_STACK, ScopeFrame},
 };
 
 /// A contextual properties that can be attached to log records.
@@ -75,7 +75,7 @@ impl LogContext {
     pub fn add_record(key: impl Into<Cow<'static, str>>, value: impl Into<LogValue>) {
         let property = (key.into(), value.into());
 
-        CONTEXT_STACK.with(|stack| {
+        SCOPE_STACK.with(|stack| {
             if let Some(mut top) = stack.top_mut() {
                 top.push(property);
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -73,11 +73,11 @@ impl LogContext {
     /// process_request(); // Will log with both request_id and processing_time_ms
     /// ```
     pub fn add_record(key: impl Into<Cow<'static, str>>, value: impl Into<LogValue>) {
-        let property = (key.into(), value.into());
+        let record = (key.into(), value.into());
 
         SCOPE_STACK.with(|stack| {
             if let Some(mut top) = stack.top_mut() {
-                top.push(property);
+                top.push(record);
             }
         });
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use crate::{
     LogValue,
     guard::LogContextGuard,
-    stack::{CONTEXT_STACK, ContextRecords},
+    stack::{CONTEXT_STACK, ScopeFrame},
 };
 
 /// A contextual properties that can be attached to log records.
@@ -13,13 +13,17 @@ use crate::{
 /// [`LogContext`] represents a set of key-value pairs that will be
 /// automatically added to log messages when the context is active.
 #[derive(Debug, Clone)]
-pub struct LogContext(pub(crate) ContextRecords);
+pub struct LogContext {
+    pub(crate) frame: ScopeFrame,
+}
 
 impl LogContext {
     /// Creates a new, empty context.
     #[must_use]
     pub const fn new() -> Self {
-        Self(ContextRecords::new())
+        Self {
+            frame: ScopeFrame::new(),
+        }
     }
 
     /// Adds property to this context.
@@ -36,8 +40,8 @@ impl LogContext {
     /// ```
     #[must_use]
     pub fn record(mut self, key: impl Into<Cow<'static, str>>, value: impl Into<LogValue>) -> Self {
-        let property = (key.into(), value.into());
-        self.0.push(property);
+        let record = (key, value);
+        self.frame.push(record);
         self
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -73,10 +73,9 @@ impl LogContext {
     /// process_request(); // Will log with both request_id and processing_time_ms
     /// ```
     pub fn add_record(key: impl Into<Cow<'static, str>>, value: impl Into<LogValue>) {
-        let record = (key.into(), value.into());
-
         SCOPE_STACK.with(|stack| {
             if let Some(mut top) = stack.top_mut() {
+                let record = (key.into(), value.into());
                 top.push(record);
             }
         });

--- a/src/future.rs
+++ b/src/future.rs
@@ -108,10 +108,10 @@ mod tests {
     use super::FutureExt;
     use crate::{LogContext, LogValue, stack::SCOPE_STACK};
 
-    fn get_property(idx: usize) -> Option<String> {
+    fn find_value(key: &str) -> Option<String> {
         SCOPE_STACK.with(|stack| {
-            let top = stack.top();
-            top.map(|frame| frame.local[idx].value().to_string())
+            let frame = stack.top()?;
+            frame.find(key).map(|r| r.value().to_string())
         })
     }
 
@@ -123,18 +123,18 @@ mod tests {
 
             async {
                 tokio::task::yield_now().await;
-                assert_eq!(get_property(0), Some("None".to_string()));
+                assert_eq!(find_value("answer"), Some("None".to_string()));
             }
             .in_log_context(LogContext::new().record("answer", LogValue::null()))
             .await;
 
             tokio::task::yield_now().await;
-            assert_eq!(get_property(0), Some(answer.to_string()));
+            assert_eq!(find_value("answer"), Some(answer.to_string()));
         }
         .in_log_context(context)
         .await;
 
-        assert_eq!(get_property(0), None);
+        assert_eq!(find_value("answer"), None);
     }
 
     #[tokio::test]
@@ -143,12 +143,12 @@ mod tests {
 
         async {
             tokio::task::yield_now().await;
-            assert_eq!(get_property(0), Some("42".to_string()));
+            assert_eq!(find_value("answer"), Some("42".to_string()));
         }
         .in_log_context(context)
         .await;
 
-        assert_eq!(get_property(0), None);
+        assert_eq!(find_value("answer"), None);
     }
 
     #[tokio::test]
@@ -166,7 +166,7 @@ mod tests {
         .await
         .unwrap_err();
 
-        assert_eq!(get_property(0), None);
+        assert_eq!(find_value("answer"), None);
     }
 
     #[tokio::test]
@@ -178,16 +178,16 @@ mod tests {
 
             async {
                 tokio::task::yield_now().await;
-                assert_eq!(get_property(0), Some("42".to_string()));
+                assert_eq!(find_value("answer"), Some("42".to_string()));
             }
             .await;
 
-            assert_eq!(get_property(0), Some("42".to_string()));
+            assert_eq!(find_value("answer"), Some("42".to_string()));
         }
         .in_log_context(context)
         .await;
 
-        assert_eq!(get_property(0), None);
+        assert_eq!(find_value("answer"), None);
     }
 
     #[tokio::test]

--- a/src/future.rs
+++ b/src/future.rs
@@ -111,7 +111,7 @@ mod tests {
     fn get_property(idx: usize) -> Option<String> {
         CONTEXT_STACK.with(|stack| {
             let top = stack.top();
-            top.map(|properties| properties[idx].1.to_string())
+            top.map(|frame| frame.local[idx].key().to_string())
         })
     }
 

--- a/src/future.rs
+++ b/src/future.rs
@@ -106,12 +106,12 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::FutureExt;
-    use crate::{LogContext, LogValue, stack::CONTEXT_STACK};
+    use crate::{LogContext, LogValue, stack::SCOPE_STACK};
 
     fn get_property(idx: usize) -> Option<String> {
-        CONTEXT_STACK.with(|stack| {
+        SCOPE_STACK.with(|stack| {
             let top = stack.top();
-            top.map(|frame| frame.local[idx].key().to_string())
+            top.map(|frame| frame.local[idx].value().to_string())
         })
     }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -50,7 +50,7 @@ impl LogContextGuard<'_> {
 
         let frame = SCOPE_STACK
             .with(ScopeStack::pop)
-            .expect("There is a bug in log context guard, context should be exists");
+            .expect("bug in LogContextGuard::exit: expected a scope frame to exist when popping on exit");
         LogContext { frame }
     }
 }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use crate::{
     LogContext,
-    stack::{CONTEXT_STACK, ContextStack},
+    stack::{SCOPE_STACK, ScopeStack},
 };
 
 /// A guard representing a current logging context in the context stack.
@@ -37,7 +37,7 @@ pub struct LogContextGuard<'a> {
 
 impl LogContextGuard<'_> {
     pub(crate) fn enter(context: LogContext) -> Self {
-        CONTEXT_STACK.with(|stack| stack.push(context.frame));
+        SCOPE_STACK.with(|stack| stack.push(context.frame));
         Self {
             _marker: PhantomData,
         }
@@ -48,8 +48,8 @@ impl LogContextGuard<'_> {
         // because we're manually managing the context stack here.
         std::mem::forget(self);
 
-        let frame = CONTEXT_STACK
-            .with(ContextStack::pop)
+        let frame = SCOPE_STACK
+            .with(ScopeStack::pop)
             .expect("There is a bug in log context guard, context should be exists");
         LogContext { frame }
     }
@@ -57,7 +57,7 @@ impl LogContextGuard<'_> {
 
 impl Drop for LogContextGuard<'_> {
     fn drop(&mut self) {
-        CONTEXT_STACK.with(ContextStack::pop);
+        SCOPE_STACK.with(ScopeStack::pop);
     }
 }
 
@@ -66,38 +66,38 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::stack::CONTEXT_STACK;
+    use crate::stack::SCOPE_STACK;
 
     #[test]
     fn test_log_context_guard_enter() {
         let context = LogContext::new().record("simple", 42);
         // Make sure the context stack is empty before entering the context.
-        assert_eq!(CONTEXT_STACK.with(ContextStack::is_empty), true);
+        assert_eq!(SCOPE_STACK.with(ScopeStack::is_empty), true);
 
         let guard = context.enter();
         // Check that the record was added to the top context.
         assert_eq!(
-            CONTEXT_STACK.with(|stack| stack.top().unwrap().local.len()),
+            SCOPE_STACK.with(|stack| stack.top().unwrap().local.len()),
             1
         );
 
         // Check that the context stack is empty after dropping the guard.
         drop(guard);
-        assert_eq!(CONTEXT_STACK.with(ContextStack::len), 0);
+        assert_eq!(SCOPE_STACK.with(ScopeStack::len), 0);
     }
 
     #[test]
     fn test_log_context_nested_guards() {
         let outer_context = LogContext::new().record("simple_record", "outer_value");
-        assert_eq!(CONTEXT_STACK.with(ContextStack::len), 0);
+        assert_eq!(SCOPE_STACK.with(ScopeStack::len), 0);
 
         let outer_guard = outer_context.enter();
         assert_eq!(
-            CONTEXT_STACK.with(|stack| stack.top().unwrap().local.len()),
+            SCOPE_STACK.with(|stack| stack.top().unwrap().local.len()),
             1
         );
 
-        CONTEXT_STACK.with(|stack| {
+        SCOPE_STACK.with(|stack| {
             let record = &stack.top().unwrap().local[0];
             assert_eq!(record.key(), "simple_record");
             assert_eq!(record.value().to_string(), "outer_value");
@@ -107,8 +107,8 @@ mod tests {
         {
             let inner_guard = inner_context.enter();
             // Test log context after inner guard is entered.
-            assert_eq!(CONTEXT_STACK.with(ContextStack::len), 2);
-            CONTEXT_STACK.with(|stack| {
+            assert_eq!(SCOPE_STACK.with(ScopeStack::len), 2);
+            SCOPE_STACK.with(|stack| {
                 let record = &stack.top().unwrap().local[0];
                 assert_eq!(record.key(), "simple_record");
                 assert_eq!(record.value().to_string(), "inner_value");
@@ -118,17 +118,17 @@ mod tests {
         }
         // Test log context after inner guard is dropped.
         assert_eq!(
-            CONTEXT_STACK.with(|stack| stack.top().unwrap().local.len()),
+            SCOPE_STACK.with(|stack| stack.top().unwrap().local.len()),
             1
         );
-        CONTEXT_STACK.with(|stack| {
+        SCOPE_STACK.with(|stack| {
             let record = &stack.top().unwrap().local[0];
             assert_eq!(record.key(), "simple_record");
             assert_eq!(record.value().to_string(), "outer_value");
         });
 
         drop(outer_guard);
-        assert_eq!(CONTEXT_STACK.with(ContextStack::is_empty), true);
+        assert_eq!(SCOPE_STACK.with(ScopeStack::is_empty), true);
     }
 
     #[test]
@@ -141,8 +141,8 @@ mod tests {
             let inner_guard = inner_context.enter();
 
             // Test log context after inner guard is entered.
-            assert_eq!(CONTEXT_STACK.with(ContextStack::len), 1);
-            CONTEXT_STACK.with(|stack| {
+            assert_eq!(SCOPE_STACK.with(ScopeStack::len), 1);
+            SCOPE_STACK.with(|stack| {
                 let record = &stack.top().unwrap().local[0];
                 assert_eq!(record.key(), "simple_record");
                 assert_eq!(record.value().to_string(), "first_thread");
@@ -154,8 +154,8 @@ mod tests {
             let inner_context = LogContext::new().record("simple_record", "second_thread");
             let inner_guard = inner_context.enter();
             // Test log context after inner guard is entered.
-            assert_eq!(CONTEXT_STACK.with(ContextStack::len), 1);
-            CONTEXT_STACK.with(|stack| {
+            assert_eq!(SCOPE_STACK.with(ScopeStack::len), 1);
+            SCOPE_STACK.with(|stack| {
                 let record = &stack.top().unwrap().local[0];
                 assert_eq!(record.key(), "simple_record");
                 assert_eq!(record.value().to_string(), "second_thread");
@@ -167,7 +167,7 @@ mod tests {
         first_thread_handle.join().unwrap();
         second_thread_handle.join().unwrap();
 
-        CONTEXT_STACK.with(|stack| {
+        SCOPE_STACK.with(|stack| {
             let record = &stack.top().unwrap().local[0];
             assert_eq!(record.key(), "simple_record");
             assert_eq!(record.value().to_string(), "main");

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -48,9 +48,9 @@ impl LogContextGuard<'_> {
         // because we're manually managing the context stack here.
         std::mem::forget(self);
 
-        let frame = SCOPE_STACK
-            .with(ScopeStack::pop)
-            .expect("bug in LogContextGuard::exit: expected a scope frame to exist when popping on exit");
+        let frame = SCOPE_STACK.with(ScopeStack::pop).expect(
+            "bug in LogContextGuard::exit: expected a scope frame to exist when popping on exit",
+        );
         LogContext { frame }
     }
 }
@@ -77,7 +77,7 @@ mod tests {
         let guard = context.enter();
         // Check that the record was added to the top context.
         assert_eq!(
-            SCOPE_STACK.with(|stack| stack.top().unwrap().local.len()),
+            SCOPE_STACK.with(|stack| stack.top().unwrap().records().len()),
             1
         );
 
@@ -93,7 +93,7 @@ mod tests {
 
         let outer_guard = outer_context.enter();
         assert_eq!(
-            SCOPE_STACK.with(|stack| stack.top().unwrap().local.len()),
+            SCOPE_STACK.with(|stack| stack.top().unwrap().records().len()),
             1
         );
 
@@ -122,7 +122,7 @@ mod tests {
         }
         // Test log context after inner guard is dropped.
         assert_eq!(
-            SCOPE_STACK.with(|stack| stack.top().unwrap().local.len()),
+            SCOPE_STACK.with(|stack| stack.top().unwrap().records().len()),
             1
         );
         SCOPE_STACK.with(|stack| {

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -37,7 +37,7 @@ pub struct LogContextGuard<'a> {
 
 impl LogContextGuard<'_> {
     pub(crate) fn enter(context: LogContext) -> Self {
-        CONTEXT_STACK.with(|stack| stack.push(context.0));
+        CONTEXT_STACK.with(|stack| stack.push(context.frame));
         Self {
             _marker: PhantomData,
         }
@@ -48,10 +48,10 @@ impl LogContextGuard<'_> {
         // because we're manually managing the context stack here.
         std::mem::forget(self);
 
-        let properties = CONTEXT_STACK
+        let frame = CONTEXT_STACK
             .with(ContextStack::pop)
             .expect("There is a bug in log context guard, context should be exists");
-        LogContext(properties)
+        LogContext { frame }
     }
 }
 
@@ -76,7 +76,10 @@ mod tests {
 
         let guard = context.enter();
         // Check that the record was added to the top context.
-        assert_eq!(CONTEXT_STACK.with(|stack| stack.top().unwrap().len()), 1);
+        assert_eq!(
+            CONTEXT_STACK.with(|stack| stack.top().unwrap().local.len()),
+            1
+        );
 
         // Check that the context stack is empty after dropping the guard.
         drop(guard);
@@ -89,12 +92,15 @@ mod tests {
         assert_eq!(CONTEXT_STACK.with(ContextStack::len), 0);
 
         let outer_guard = outer_context.enter();
-        assert_eq!(CONTEXT_STACK.with(|stack| stack.top().unwrap().len()), 1);
+        assert_eq!(
+            CONTEXT_STACK.with(|stack| stack.top().unwrap().local.len()),
+            1
+        );
 
         CONTEXT_STACK.with(|stack| {
-            let property = &stack.top().unwrap()[0];
-            assert_eq!(property.0, "simple_record");
-            assert_eq!(property.1.to_string(), "outer_value");
+            let record = &stack.top().unwrap().local[0];
+            assert_eq!(record.key(), "simple_record");
+            assert_eq!(record.value().to_string(), "outer_value");
         });
 
         let inner_context = LogContext::new().record("simple_record", "inner_value");
@@ -103,19 +109,22 @@ mod tests {
             // Test log context after inner guard is entered.
             assert_eq!(CONTEXT_STACK.with(ContextStack::len), 2);
             CONTEXT_STACK.with(|stack| {
-                let property = &stack.top().unwrap()[0];
-                assert_eq!(property.0, "simple_record");
-                assert_eq!(property.1.to_string(), "inner_value");
+                let record = &stack.top().unwrap().local[0];
+                assert_eq!(record.key(), "simple_record");
+                assert_eq!(record.value().to_string(), "inner_value");
             });
 
             drop(inner_guard);
         }
         // Test log context after inner guard is dropped.
-        assert_eq!(CONTEXT_STACK.with(|stack| stack.top().unwrap().len()), 1);
+        assert_eq!(
+            CONTEXT_STACK.with(|stack| stack.top().unwrap().local.len()),
+            1
+        );
         CONTEXT_STACK.with(|stack| {
-            let property = &stack.top().unwrap()[0];
-            assert_eq!(property.0, "simple_record");
-            assert_eq!(property.1.to_string(), "outer_value");
+            let record = &stack.top().unwrap().local[0];
+            assert_eq!(record.key(), "simple_record");
+            assert_eq!(record.value().to_string(), "outer_value");
         });
 
         drop(outer_guard);
@@ -134,9 +143,9 @@ mod tests {
             // Test log context after inner guard is entered.
             assert_eq!(CONTEXT_STACK.with(ContextStack::len), 1);
             CONTEXT_STACK.with(|stack| {
-                let property = &stack.top().unwrap()[0];
-                assert_eq!(property.0, "simple_record");
-                assert_eq!(property.1.to_string(), "first_thread");
+                let record = &stack.top().unwrap().local[0];
+                assert_eq!(record.key(), "simple_record");
+                assert_eq!(record.value().to_string(), "first_thread");
             });
 
             drop(inner_guard);
@@ -147,9 +156,9 @@ mod tests {
             // Test log context after inner guard is entered.
             assert_eq!(CONTEXT_STACK.with(ContextStack::len), 1);
             CONTEXT_STACK.with(|stack| {
-                let property = &stack.top().unwrap()[0];
-                assert_eq!(property.0, "simple_record");
-                assert_eq!(property.1.to_string(), "second_thread");
+                let record = &stack.top().unwrap().local[0];
+                assert_eq!(record.key(), "simple_record");
+                assert_eq!(record.value().to_string(), "second_thread");
             });
 
             drop(inner_guard);
@@ -159,9 +168,9 @@ mod tests {
         second_thread_handle.join().unwrap();
 
         CONTEXT_STACK.with(|stack| {
-            let property = &stack.top().unwrap()[0];
-            assert_eq!(property.0, "simple_record");
-            assert_eq!(property.1.to_string(), "main");
+            let record = &stack.top().unwrap().local[0];
+            assert_eq!(record.key(), "simple_record");
+            assert_eq!(record.value().to_string(), "main");
         });
         drop(local_guard);
     }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -98,9 +98,11 @@ mod tests {
         );
 
         SCOPE_STACK.with(|stack| {
-            let record = &stack.top().unwrap().local[0];
-            assert_eq!(record.key(), "simple_record");
-            assert_eq!(record.value().to_string(), "outer_value");
+            let frame = stack.top().unwrap();
+            assert_eq!(
+                frame.find("simple_record").unwrap().value().to_string(),
+                "outer_value"
+            );
         });
 
         let inner_context = LogContext::new().record("simple_record", "inner_value");
@@ -109,9 +111,11 @@ mod tests {
             // Test log context after inner guard is entered.
             assert_eq!(SCOPE_STACK.with(ScopeStack::len), 2);
             SCOPE_STACK.with(|stack| {
-                let record = &stack.top().unwrap().local[0];
-                assert_eq!(record.key(), "simple_record");
-                assert_eq!(record.value().to_string(), "inner_value");
+                let frame = stack.top().unwrap();
+                assert_eq!(
+                    frame.find("simple_record").unwrap().value().to_string(),
+                    "inner_value"
+                );
             });
 
             drop(inner_guard);
@@ -122,9 +126,11 @@ mod tests {
             1
         );
         SCOPE_STACK.with(|stack| {
-            let record = &stack.top().unwrap().local[0];
-            assert_eq!(record.key(), "simple_record");
-            assert_eq!(record.value().to_string(), "outer_value");
+            let frame = stack.top().unwrap();
+            assert_eq!(
+                frame.find("simple_record").unwrap().value().to_string(),
+                "outer_value"
+            );
         });
 
         drop(outer_guard);
@@ -143,9 +149,11 @@ mod tests {
             // Test log context after inner guard is entered.
             assert_eq!(SCOPE_STACK.with(ScopeStack::len), 1);
             SCOPE_STACK.with(|stack| {
-                let record = &stack.top().unwrap().local[0];
-                assert_eq!(record.key(), "simple_record");
-                assert_eq!(record.value().to_string(), "first_thread");
+                let frame = stack.top().unwrap();
+                assert_eq!(
+                    frame.find("simple_record").unwrap().value().to_string(),
+                    "first_thread"
+                );
             });
 
             drop(inner_guard);
@@ -156,9 +164,11 @@ mod tests {
             // Test log context after inner guard is entered.
             assert_eq!(SCOPE_STACK.with(ScopeStack::len), 1);
             SCOPE_STACK.with(|stack| {
-                let record = &stack.top().unwrap().local[0];
-                assert_eq!(record.key(), "simple_record");
-                assert_eq!(record.value().to_string(), "second_thread");
+                let frame = stack.top().unwrap();
+                assert_eq!(
+                    frame.find("simple_record").unwrap().value().to_string(),
+                    "second_thread"
+                );
             });
 
             drop(inner_guard);
@@ -168,9 +178,11 @@ mod tests {
         second_thread_handle.join().unwrap();
 
         SCOPE_STACK.with(|stack| {
-            let record = &stack.top().unwrap().local[0];
-            assert_eq!(record.key(), "simple_record");
-            assert_eq!(record.value().to_string(), "main");
+            let frame = stack.top().unwrap();
+            assert_eq!(
+                frame.find("simple_record").unwrap().value().to_string(),
+                "main"
+            );
         });
         drop(local_guard);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,10 @@ impl log::Log for ContextLogger {
 
     fn log(&self, record: &log::Record) {
         let error = SCOPE_STACK.try_with(|stack| {
+            // Only the top frame is read here intentionally: when scope inheritance is
+            // implemented (see issue #16), inherited records from outer scopes will be
+            // automatically copied into the new top frame on `enter()`, so the top frame
+            // will always contain a complete, flat view of all active records.
             if let Some(top) = stack.top() {
                 self.inner.log(
                     &record

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ mod value;
 ///
 /// See [`LogContext`] for more information on how to create and manage context properties.
 pub struct ContextLogger {
-    default_records: Vec<LogRecord>,
+    records: Vec<LogRecord>,
     inner: Box<dyn log::Log>,
 }
 
@@ -86,7 +86,7 @@ impl ContextLogger {
         L: log::Log + 'static,
     {
         Self {
-            default_records: Vec::new(),
+            records: Vec::new(),
             inner: Box::new(inner),
         }
     }
@@ -153,7 +153,7 @@ impl ContextLogger {
         key: impl Into<Cow<'static, str>>,
         value: impl Into<LogValue>,
     ) -> Self {
-        self.default_records.push((key, value).into());
+        self.records.push((key, value).into());
         self
     }
 }
@@ -172,21 +172,25 @@ impl log::Log for ContextLogger {
     fn log(&self, record: &log::Record) {
         let error = SCOPE_STACK.try_with(|stack| {
             if let Some(top) = stack.top() {
-                let extra_records = ExtraRecords {
-                    source: &record.key_values(),
-                    default_records: self.default_records.as_slice(),
-                    context_records: top.local.as_slice(),
-                };
-                self.inner
-                    .log(&record.to_builder().key_values(&extra_records).build());
+                self.inner.log(
+                    &record
+                        .to_builder()
+                        .key_values(&SourceWithRecords {
+                            source: &record.key_values(),
+                            records: self.records.iter().chain(top.records()),
+                        })
+                        .build(),
+                );
             } else {
-                let extra_records = ExtraRecords {
-                    source: &record.key_values(),
-                    default_records: self.default_records.as_slice(),
-                    context_records: &[],
-                };
-                self.inner
-                    .log(&record.to_builder().key_values(&extra_records).build());
+                self.inner.log(
+                    &record
+                        .to_builder()
+                        .key_values(&SourceWithRecords {
+                            source: &record.key_values(),
+                            records: self.records.iter(),
+                        })
+                        .build(),
+                );
             }
         });
 
@@ -204,22 +208,20 @@ impl log::Log for ContextLogger {
     }
 }
 
-struct ExtraRecords<'a, I> {
+struct SourceWithRecords<'a, I> {
     source: &'a dyn log::kv::Source,
-    default_records: I,
-    context_records: I,
+    records: I,
 }
 
-impl<'a, I> log::kv::Source for ExtraRecords<'a, I>
+impl<'a, I> log::kv::Source for SourceWithRecords<'a, I>
 where
-    I: IntoIterator<Item = &'a LogRecord> + Copy,
+    I: Iterator<Item = &'a LogRecord> + Clone,
 {
     fn visit<'kvs>(
         &'kvs self,
         visitor: &mut dyn log::kv::VisitSource<'kvs>,
     ) -> Result<(), log::kv::Error> {
-        let all_records = self.default_records.into_iter().chain(self.context_records);
-        for record in all_records {
+        for record in self.records.clone() {
             visitor.visit_pair(
                 log::kv::Key::from_str(record.key()),
                 record.value().as_log_value(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,14 @@
 
 use std::borrow::Cow;
 
-use stack::ContextRecords;
-
 use self::stack::CONTEXT_STACK;
 pub use self::{context::LogContext, future::FutureExt, value::LogValue};
+use crate::record::LogRecord;
 
 mod context;
 pub mod future;
 pub mod guard;
+mod record;
 mod stack;
 mod value;
 
@@ -72,7 +72,7 @@ mod value;
 ///
 /// See [`LogContext`] for more information on how to create and manage context properties.
 pub struct ContextLogger {
-    default_records: ContextRecords,
+    default_records: Vec<LogRecord>,
     inner: Box<dyn log::Log>,
 }
 
@@ -86,7 +86,7 @@ impl ContextLogger {
         L: log::Log + 'static,
     {
         Self {
-            default_records: ContextRecords::new(),
+            default_records: Vec::new(),
             inner: Box::new(inner),
         }
     }
@@ -153,7 +153,7 @@ impl ContextLogger {
         key: impl Into<Cow<'static, str>>,
         value: impl Into<LogValue>,
     ) -> Self {
-        self.default_records.push((key.into(), value.into()));
+        self.default_records.push((key, value).into());
         self
     }
 }
@@ -175,7 +175,7 @@ impl log::Log for ContextLogger {
                 let extra_records = ExtraRecords {
                     source: &record.key_values(),
                     default_records: self.default_records.as_slice(),
-                    context_records: top.as_slice(),
+                    context_records: top.local.as_slice(),
                 };
                 self.inner
                     .log(&record.to_builder().key_values(&extra_records).build());
@@ -212,15 +212,18 @@ struct ExtraRecords<'a, I> {
 
 impl<'a, I> log::kv::Source for ExtraRecords<'a, I>
 where
-    I: IntoIterator<Item = &'a (Cow<'static, str>, LogValue)> + Copy,
+    I: IntoIterator<Item = &'a LogRecord> + Copy,
 {
     fn visit<'kvs>(
         &'kvs self,
         visitor: &mut dyn log::kv::VisitSource<'kvs>,
     ) -> Result<(), log::kv::Error> {
         let all_records = self.default_records.into_iter().chain(self.context_records);
-        for (key, value) in all_records {
-            visitor.visit_pair(log::kv::Key::from_str(key), value.as_log_value())?;
+        for record in all_records {
+            visitor.visit_pair(
+                log::kv::Key::from_str(record.key()),
+                record.value().as_log_value(),
+            )?;
         }
         self.source.visit(visitor)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,11 @@ mod record;
 mod stack;
 mod value;
 
-/// A logger wrapper that enhances log records with contextual properties.
+/// A logger wrapper that enhances log records with scope records.
 ///
 /// `ContextLogger` wraps an existing logging implementation and adds additional
-/// context properties to log records. These context properties are taken from the
-/// current context stack, which is managed by the [`LogContext`] type.
+/// scope records to log records. These records are taken from the
+/// current scope stack, which is managed by the [`LogContext`] type.
 ///
 /// # Example
 ///
@@ -67,10 +67,10 @@ mod value;
 ///
 /// // Use the context while logging
 /// let _guard = ctx.enter();
-/// info!("Processing request"); // Will include request_id and user_id properties
+/// info!("Processing request"); // Will include request_id and user_id records
 /// ```
 ///
-/// See [`LogContext`] for more information on how to create and manage context properties.
+/// See [`LogContext`] for more information on how to create and manage scope records.
 pub struct ContextLogger {
     records: Vec<LogRecord>,
     inner: Box<dyn log::Log>,
@@ -79,8 +79,8 @@ pub struct ContextLogger {
 impl ContextLogger {
     /// Creates a new [`ContextLogger`] that wraps the given logging implementation.
     ///
-    /// The inner logger will receive log records enhanced with context properties
-    /// from the current context stack.
+    /// The inner logger will receive log records enhanced with scope records
+    /// from the current scope stack.
     pub fn new<L>(inner: L) -> Self
     where
         L: log::Log + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 
 use std::borrow::Cow;
 
-use self::stack::CONTEXT_STACK;
+use self::stack::SCOPE_STACK;
 pub use self::{context::LogContext, future::FutureExt, value::LogValue};
 use crate::record::LogRecord;
 
@@ -170,7 +170,7 @@ impl log::Log for ContextLogger {
     }
 
     fn log(&self, record: &log::Record) {
-        let error = CONTEXT_STACK.try_with(|stack| {
+        let error = SCOPE_STACK.try_with(|stack| {
             if let Some(top) = stack.top() {
                 let extra_records = ExtraRecords {
                     source: &record.key_values(),

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,0 +1,47 @@
+//! Internal representation of a single contextual log record.
+//!
+//! This module provides the [`LogRecord`] type, which is used internally by the
+//! context-logger library to represent individual context fields before they are
+//! converted to the appropriate format for the underlying logging implementation.
+
+use std::borrow::Cow;
+
+use crate::LogValue;
+
+/// A single contextual log record.
+///
+/// This type represents a key-value pair that can be attached to log records
+/// through the [`crate::LogContext`] API. It is used internally by the
+/// context-logger library.
+#[derive(Debug, Clone)]
+pub struct LogRecord {
+    key: Cow<'static, str>,
+    value: LogValue,
+}
+
+impl LogRecord {
+    /// Creates a new [`LogRecord`] with the given key and value.
+    pub const fn new(key: Cow<'static, str>, value: LogValue) -> Self {
+        Self { key, value }
+    }
+
+    /// Returns the key of this record.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Returns the value of this record.
+    pub const fn value(&self) -> &LogValue {
+        &self.value
+    }
+}
+
+impl<K, V> From<(K, V)> for LogRecord
+where
+    K: Into<Cow<'static, str>>,
+    V: Into<LogValue>,
+{
+    fn from((key, value): (K, V)) -> Self {
+        Self::new(key.into(), value.into())
+    }
+}

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -21,7 +21,7 @@ thread_local! {
 #[derive(Debug, Clone)]
 pub struct ScopeFrame {
     /// Records attached at this scope level.
-    pub local: Vec<LogRecord>,
+    local: Vec<LogRecord>,
 }
 
 /// A stack of scope frames, one per active [`crate::LogContextGuard`].
@@ -37,6 +37,10 @@ impl ScopeFrame {
 
     pub fn push(&mut self, record: impl Into<LogRecord>) {
         self.local.push(record.into());
+    }
+
+    pub fn records(&self) -> impl ExactSizeIterator<Item = &LogRecord> + Clone {
+        self.local.iter()
     }
 
     /// Returns the first record with the given key, or `None` if not found.

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -8,7 +8,7 @@ use std::cell::{Ref, RefCell, RefMut};
 use crate::record::LogRecord;
 
 thread_local! {
-    /// Thread-local stack for maintaining log context.
+    /// Thread-local stack for maintaining log scopes.
     ///
     /// Each thread has its own independent stack ensuring thread-safety without
     /// expensive synchronization.
@@ -37,6 +37,14 @@ impl ScopeFrame {
 
     pub fn push(&mut self, record: impl Into<LogRecord>) {
         self.local.push(record.into());
+    }
+
+    /// Returns the first record with the given key, or `None` if not found.
+    ///
+    /// Performs a linear scan over all records in the frame — O(n).
+    #[cfg(test)]
+    pub fn find(&self, key: &str) -> Option<&LogRecord> {
+        self.local.iter().find(|r| r.key() == key)
     }
 }
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -12,17 +12,21 @@ thread_local! {
     ///
     /// Each thread has its own independent stack ensuring thread-safety without
     /// expensive synchronization.
-    pub static CONTEXT_STACK: ContextStack = const { ContextStack::new() };
+    pub static SCOPE_STACK: ScopeStack = const { ScopeStack::new() };
 }
 
+/// A single frame in the thread-local [`ScopeStack`].
+///
+/// Pushed when a scope is entered and popped when its guard is dropped.
 #[derive(Debug, Clone)]
 pub struct ScopeFrame {
+    /// Records attached at this scope level.
     pub local: Vec<LogRecord>,
 }
 
-/// A stack of context properties.
+/// A stack of scope frames, one per active [`crate::LogContextGuard`].
 #[derive(Debug)]
-pub struct ContextStack {
+pub struct ScopeStack {
     inner: RefCell<Vec<ScopeFrame>>,
 }
 
@@ -36,7 +40,7 @@ impl ScopeFrame {
     }
 }
 
-impl ContextStack {
+impl ScopeStack {
     /// Creates a new, empty context stack.
     pub const fn new() -> Self {
         Self {
@@ -91,14 +95,14 @@ impl ContextStack {
     }
 }
 
-impl Default for ContextStack {
+impl Default for ScopeStack {
     fn default() -> Self {
         Self::new()
     }
 }
 
 #[cfg(test)]
-impl ContextStack {
+impl ScopeStack {
     pub fn len(&self) -> usize {
         self.inner.borrow().len()
     }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,6 +1,6 @@
 //! Internal thread-local stack for maintaining log scopes.
 //!
-//! The stack is used by both the syncrhonous and asynchronous log
+//! The stack is used by both the synchronous and asynchronous log
 //! context propagation mechanisms.
 
 use std::cell::{Ref, RefCell, RefMut};

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,4 +1,4 @@
-//! Internal thread-local stack for maintaining log context.
+//! Internal thread-local stack for maintaining log scopes.
 //!
 //! The stack is used by both the syncrhonous and asynchronous log
 //! context propagation mechanisms.
@@ -53,14 +53,14 @@ impl ScopeFrame {
 }
 
 impl ScopeStack {
-    /// Creates a new, empty context stack.
+    /// Creates a new, empty scope stack.
     pub const fn new() -> Self {
         Self {
             inner: RefCell::new(Vec::new()),
         }
     }
 
-    /// Pushes a new set of context properties onto the stack.
+    /// Pushes a new scope frame onto the stack.
     ///
     /// # Panics
     ///
@@ -69,7 +69,7 @@ impl ScopeStack {
         self.inner.borrow_mut().push(frame);
     }
 
-    /// Pops the top set of context properties from the stack.
+    /// Pops the top scope frame from the stack.
     ///
     /// # Panics
     ///
@@ -78,7 +78,7 @@ impl ScopeStack {
         self.inner.borrow_mut().pop()
     }
 
-    /// Returns a reference to the top set of context properties on the stack.
+    /// Returns a reference to the top scope frame on the stack.
     ///
     /// # Panics
     ///
@@ -92,7 +92,7 @@ impl ScopeStack {
         }
     }
 
-    /// Returns a mutable reference to the top set of context properties on the stack.
+    /// Returns a mutable reference to the top scope frame on the stack.
     ///
     /// # Panics
     ///

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -3,12 +3,9 @@
 //! The stack is used by both the syncrhonous and asynchronous log
 //! context propagation mechanisms.
 
-use std::{
-    borrow::Cow,
-    cell::{Ref, RefCell, RefMut},
-};
+use std::cell::{Ref, RefCell, RefMut};
 
-use crate::LogValue;
+use crate::record::LogRecord;
 
 thread_local! {
     /// Thread-local stack for maintaining log context.
@@ -18,12 +15,25 @@ thread_local! {
     pub static CONTEXT_STACK: ContextStack = const { ContextStack::new() };
 }
 
-pub type ContextRecords = Vec<(Cow<'static, str>, LogValue)>;
+#[derive(Debug, Clone)]
+pub struct ScopeFrame {
+    pub local: Vec<LogRecord>,
+}
 
 /// A stack of context properties.
 #[derive(Debug)]
 pub struct ContextStack {
-    inner: RefCell<Vec<ContextRecords>>,
+    inner: RefCell<Vec<ScopeFrame>>,
+}
+
+impl ScopeFrame {
+    pub const fn new() -> Self {
+        Self { local: Vec::new() }
+    }
+
+    pub fn push(&mut self, record: impl Into<LogRecord>) {
+        self.local.push(record.into());
+    }
 }
 
 impl ContextStack {
@@ -39,8 +49,8 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already borrowed.
-    pub fn push(&self, records: ContextRecords) {
-        self.inner.borrow_mut().push(records);
+    pub fn push(&self, frame: ScopeFrame) {
+        self.inner.borrow_mut().push(frame);
     }
 
     /// Pops the top set of context properties from the stack.
@@ -48,7 +58,7 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already borrowed.
-    pub fn pop(&self) -> Option<ContextRecords> {
+    pub fn pop(&self) -> Option<ScopeFrame> {
         self.inner.borrow_mut().pop()
     }
 
@@ -57,7 +67,7 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already mutably borrowed.
-    pub fn top(&self) -> Option<Ref<'_, ContextRecords>> {
+    pub fn top(&self) -> Option<Ref<'_, ScopeFrame>> {
         let inner = self.inner.borrow();
         if inner.is_empty() {
             None
@@ -71,7 +81,7 @@ impl ContextStack {
     /// # Panics
     ///
     /// If the stack is already borrowed.
-    pub fn top_mut(&self) -> Option<RefMut<'_, ContextRecords>> {
+    pub fn top_mut(&self) -> Option<RefMut<'_, ScopeFrame>> {
         let inner = self.inner.borrow_mut();
         if inner.is_empty() {
             None


### PR DESCRIPTION
Renames and restructures the internal representation of the logging context stack
to better reflect the domain mode

Second part of #17 