### PR TITLE
Introduce LogScope structure instead of LogContextGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to
 - _breaking_ Moved `LogContext::add_record` to `LogScope::add_record`; dynamic
   record insertion is now clearly associated with the active scope rather than
   the context builder
-- _breaking_ Removed `LogScopeGuard` from the public API
+- _breaking_ Renamed `LogContextGuard` to `LogScope` in the public API
 - _breaking_ Renamed `ContextValue` to `LogValue` to better reflect its role in
   structured logging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+- _breaking_ Renamed `LogContext::record` to `LogContext::with_record` to follow
+  the standard Rust builder pattern naming convention
+- _breaking_ Replaced `LogContext::enter` instance method with the
+  `LogScope::enter(context)` static method; `LogScope` is now the explicit guard
+  type that keeps the context active and removes it from the stack on drop
+- _breaking_ Moved `LogContext::add_record` to `LogScope::add_record`; dynamic
+  record insertion is now clearly associated with the active scope rather than
+  the context builder
+- _breaking_ Removed `LogScopeGuard` from the public API
 - _breaking_ Renamed `ContextValue` to `LogValue` to better reflect its role in
   structured logging
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "static_assertions",
  "structured-logger",
  "tokio",
 ]
@@ -527,6 +528,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "structured-logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures-util = "0.3"
 pretty_assertions = "1.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+static_assertions = "1"
 structured-logger = { version = "1.0" }
 tokio = { version = "1.45", features = ["macros", "rt-multi-thread", "time"] }
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, you can use it in your code:
 <!-- ANCHOR: basic_example -->
 
 ```rust
-use context_logger::{ContextLogger, LogContext};
+use context_logger::{ContextLogger, LogContext, LogScope};
 use log::info;
 
 fn main() {
@@ -44,16 +44,16 @@ fn main() {
         // Add version default record.
         .default_record("version", "1.0.0");
     // Initialize the resulting logger.
-    context_logger.init(max_level);   
+    context_logger.init(max_level);
 
     // Create a context
     let ctx = LogContext::new()
-        .record("request_id", "req-123")
-        .record("user_id", 42);
-    
+        .with_record("request_id", "req-123")
+        .with_record("user_id", 42);
+
     // Use the context
-    let _guard = ctx.enter();
-    
+    let _guard = LogScope::enter(ctx);
+
     // Log with context automatically attached
     info!("Processing request"); // Will include version=1.0.0 request_id=req-123 and user_id=42
 }
@@ -69,18 +69,18 @@ Context logger supports async functions and can propagate log context across
 `.await` points.
 
 ```rust
-use context_logger::{ContextLogger, LogContext, FutureExt};
+use context_logger::{ContextLogger, LogContext, FutureExt, LogScope};
 use log::info;
 
 async fn process_user_data(user_id: &str) {
-    let context = LogContext::new().record("user_id", user_id);
-    
+    let context = LogContext::new().with_record("user_id", user_id);
+
     async {
         info!("Processing user data"); // Includes user_id
-        
+
         // Context automatically propagates through .await points
         fetch_user_preferences().await;
-        
+
         info!("User data processed"); // Still includes user_id
     }
     .in_log_context(context)
@@ -89,7 +89,7 @@ async fn process_user_data(user_id: &str) {
 
 async fn fetch_user_preferences() {
     // Add additional context for this specific operation
-    LogContext::add_record("operation", "fetch_preferences");
+    LogScope::add_record("operation", "fetch_preferences");
     info!("Fetching preferences"); // Includes both user_id and operation
 }
 ```

--- a/examples/contexted_log_async.rs
+++ b/examples/contexted_log_async.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use context_logger::{ContextLogger, FutureExt, LogContext, LogValue};
+use context_logger::{ContextLogger, FutureExt, LogContext, LogScope, LogValue};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             log::info!("Third future pending");
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            LogContext::add_record(
+            LogScope::add_record(
                 "operation",
                 LogValue::serde(Operation {
                     action: "logout".to_owned(),
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .record("age", 35)
         .record("email", "charlie@example.com");
 
-    let _guard = context.enter();
+    let _guard = LogScope::enter(context);
 
     log::info!("Last call completed");
 

--- a/examples/contexted_log_async.rs
+++ b/examples/contexted_log_async.rs
@@ -29,11 +29,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Initialized context logger");
 
     // Create a new context with properties.
-    let log_context = LogContext::new().record("user_id", "12345");
+    let log_context = LogContext::new().with_record("user_id", "12345");
     let first_future = async move {
         log::info!("Logging in");
         // Create a nested context with additional properties
-        let log_context = LogContext::new().record(
+        let log_context = LogContext::new().with_record(
             "action",
             LogValue::serde(Operation {
                 action: "login".to_string(),
@@ -53,10 +53,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .in_log_context(log_context);
 
     let log_context = LogContext::new()
-        .record("name", "Alice")
-        .record("age", 25)
-        .record("married", true)
-        .record("email", "alice@example.com");
+        .with_record("name", "Alice")
+        .with_record("age", 25)
+        .with_record("married", true)
+        .with_record("email", "alice@example.com");
     let second_future = async move {
         tokio::task::yield_now().await;
 
@@ -67,9 +67,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .in_log_context(log_context);
 
     let log_context = LogContext::new()
-        .record("name", "Bob")
-        .record("age", 30)
-        .record("email", "bob@example.com");
+        .with_record("name", "Bob")
+        .with_record("age", 30)
+        .with_record("email", "bob@example.com");
     let third_future = tokio::spawn(
         async move {
             tokio::task::yield_now().await;
@@ -93,9 +93,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     res?;
 
     let context = LogContext::new()
-        .record("name", "Charlie")
-        .record("age", 35)
-        .record("email", "charlie@example.com");
+        .with_record("name", "Charlie")
+        .with_record("age", 35)
+        .with_record("email", "charlie@example.com");
 
     let _guard = LogScope::enter(context);
 

--- a/examples/contexted_log_sync.rs
+++ b/examples/contexted_log_sync.rs
@@ -27,13 +27,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a new context with properties
     {
-        let _guard = LogScope::enter(LogContext::new().record("user_id", "12345"));
+        let _guard = LogScope::enter(LogContext::new().with_record("user_id", "12345"));
 
         log::info!("Logging in");
 
         // Create a nested context with additional properties
         {
-            let context = LogContext::new().record(
+            let context = LogContext::new().with_record(
                 "action",
                 LogValue::serde(Operation {
                     action: "login".to_string(),

--- a/examples/contexted_log_sync.rs
+++ b/examples/contexted_log_sync.rs
@@ -1,4 +1,4 @@
-use context_logger::{ContextLogger, LogContext, LogValue};
+use context_logger::{ContextLogger, LogContext, LogScope, LogValue};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -27,21 +27,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a new context with properties
     {
-        let _guard = LogContext::new().record("user_id", "12345").enter();
+        let _guard = LogScope::enter(LogContext::new().record("user_id", "12345"));
 
         log::info!("Logging in");
 
         // Create a nested context with additional properties
         {
-            let _nested_guard = LogContext::new()
-                .record(
-                    "action",
-                    LogValue::serde(Operation {
-                        action: "login".to_string(),
-                        name: "user".to_string(),
-                    }),
-                )
-                .enter();
+            let context = LogContext::new().record(
+                "action",
+                LogValue::serde(Operation {
+                    action: "login".to_string(),
+                    name: "user".to_string(),
+                }),
+            );
+            let _nested_guard = LogScope::enter(context);
             log::info!("User logged in successfully");
         }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -30,9 +30,9 @@ impl LogContext {
     /// use context_logger::LogContext;
     ///
     /// let context = LogContext::new()
-    ///     .record("user_id", "user-123")
-    ///     .record("request_id", 42)
-    ///     .record("is_admin", true);
+    ///     .with_record("user_id", "user-123")
+    ///     .with_record("request_id", 42)
+    ///     .with_record("is_admin", true);
     /// ```
     #[must_use]
     pub fn with_record(

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 
 use crate::{
     LogValue,
-    guard::LogContextGuard,
     stack::{SCOPE_STACK, ScopeFrame},
 };
 
@@ -43,72 +42,6 @@ impl LogContext {
         let record = (key, value);
         self.frame.push(record);
         self
-    }
-
-    /// Adds a record to the currently active scope.
-    ///
-    /// This is useful for adding records dynamically without having
-    /// direct access to the current scope.
-    ///
-    /// # Note
-    ///
-    /// If there is no active context, this operation will have no effect.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use context_logger::{LogContext, LogValue};
-    /// use log::info;
-    ///
-    /// fn process_request() {
-    ///     // Add a record to the current scope dynamically
-    ///     LogContext::add_record("processing_time_ms", 42);
-    ///     info!("Request processed");
-    /// }
-    ///
-    /// let _guard = LogContext::new()
-    ///     .record("request_id", "req-123")
-    ///     .enter();
-    ///
-    /// process_request(); // Will log with both request_id and processing_time_ms
-    /// ```
-    pub fn add_record(key: impl Into<Cow<'static, str>>, value: impl Into<LogValue>) {
-        SCOPE_STACK.with(|stack| {
-            if let Some(mut top) = stack.top_mut() {
-                let record = (key.into(), value.into());
-                top.push(record);
-            }
-        });
-    }
-
-    /// Activates this scope, returning a guard that will exit the scope when dropped.
-    ///
-    /// # In Asynchronous Code
-    ///
-    /// *Warning:* in asynchronous code [`Self::enter`] should be used very carefully or avoided entirely.
-    /// Holding the drop guard across `.await` points will result in incorrect logs:
-    ///
-    /// ```rust
-    /// use context_logger::LogContext;
-    ///
-    /// async fn my_async_fn() {
-    ///     let ctx = LogContext::new()
-    ///         .record("request_id", "req-123")
-    ///         .record("user_id", 42);
-    ///     // WARNING: This context will remain active until this
-    ///     // guard is dropped...
-    ///     let _guard = ctx.enter();
-    ///     // But this code causing the runtime to switch to another task,
-    ///     // while remaining in this context.
-    ///     tokio::task::yield_now().await;
-    ///     }
-    /// ```
-    ///
-    /// Please use the [`crate::FutureExt::in_log_context`] instead.
-    ///
-    #[must_use]
-    pub fn enter<'a>(self) -> LogContextGuard<'a> {
-        LogContextGuard::enter(self)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,15 +2,12 @@
 
 use std::borrow::Cow;
 
-use crate::{
-    LogValue,
-    stack::{SCOPE_STACK, ScopeFrame},
-};
+use crate::{LogValue, stack::ScopeFrame};
 
 /// A set of records that can be attached to a logging scope.
 ///
 /// [`LogContext`] represents a set of key-value pairs that will be
-/// automatically added to log messages when the context is active.
+/// automatically added to log messages when the context scope is active.
 #[derive(Debug, Clone)]
 pub struct LogContext {
     pub(crate) frame: ScopeFrame,
@@ -38,7 +35,11 @@ impl LogContext {
     ///     .record("is_admin", true);
     /// ```
     #[must_use]
-    pub fn record(mut self, key: impl Into<Cow<'static, str>>, value: impl Into<LogValue>) -> Self {
+    pub fn with_record(
+        mut self,
+        key: impl Into<Cow<'static, str>>,
+        value: impl Into<LogValue>,
+    ) -> Self {
         let record = (key, value);
         self.frame.push(record);
         self

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,7 +22,7 @@ impl LogContext {
         }
     }
 
-    /// Adds a record to this scope.
+    /// Adds a record to this context.
     ///
     /// # Examples
     ///

--- a/src/future.rs
+++ b/src/future.rs
@@ -26,8 +26,8 @@ pub trait FutureExt: Sized + private::Sealed {
     /// async fn process_user_data(user_id: u64) {
     ///     // Create a context with user information
     ///     let context = LogContext::new()
-    ///         .record("user_id", user_id)
-    ///         .record("operation", "process_data");
+    ///         .with_record("user_id", user_id)
+    ///         .with_record("operation", "process_data");
     ///
     ///     async {
     ///         info!("Starting user data processing"); // Will include context

--- a/src/future.rs
+++ b/src/future.rs
@@ -4,7 +4,7 @@ use std::task::Poll;
 
 use pin_project::pin_project;
 
-use crate::LogContext;
+use crate::{LogContext, scope::LogScope};
 
 /// Extension trait for futures to propagate contextual logging information.
 ///
@@ -84,7 +84,7 @@ where
             .take()
             .expect("An attempt to poll panicked future");
 
-        let guard = log_context.enter();
+        let guard = LogScope::enter(log_context);
         let result = this.inner.poll(cx);
         this.log_context.replace(guard.exit());
 

--- a/src/future.rs
+++ b/src/future.rs
@@ -116,7 +116,7 @@ mod tests {
     }
 
     async fn check_nested_different_contexts(answer: u32) {
-        let context = LogContext::new().record("answer", answer);
+        let context = LogContext::new().with_record("answer", answer);
 
         async {
             tokio::task::yield_now().await;
@@ -125,7 +125,7 @@ mod tests {
                 tokio::task::yield_now().await;
                 assert_eq!(find_value("answer"), Some("None".to_string()));
             }
-            .in_log_context(LogContext::new().record("answer", LogValue::null()))
+            .in_log_context(LogContext::new().with_record("answer", LogValue::null()))
             .await;
 
             tokio::task::yield_now().await;
@@ -139,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_future_with_context() {
-        let context = LogContext::new().record("answer", 42);
+        let context = LogContext::new().with_record("answer", 42);
 
         async {
             tokio::task::yield_now().await;
@@ -153,7 +153,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_panicked_future() {
-        let context = LogContext::new().record("answer", 42);
+        let context = LogContext::new().with_record("answer", 42);
 
         AssertUnwindSafe(
             async {
@@ -171,7 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_nested_future_with_common_context() {
-        let context = LogContext::new().record("answer", 42);
+        let context = LogContext::new().with_record("answer", 42);
 
         async {
             tokio::task::yield_now().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,18 @@
 
 use std::borrow::Cow;
 
-use self::stack::SCOPE_STACK;
-pub use self::{context::LogContext, future::FutureExt, value::LogValue};
-use crate::record::LogRecord;
+pub use self::{
+    context::LogContext,
+    future::FutureExt,
+    scope::{LogScope, LogScopeGuard},
+    value::LogValue,
+};
+use crate::{record::LogRecord, stack::SCOPE_STACK};
 
 mod context;
 pub mod future;
-pub mod guard;
 mod record;
+mod scope;
 mod stack;
 mod value;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ mod value;
 ///
 /// ```
 /// use log::{info, LevelFilter};
-/// use context_logger::{ContextLogger, LogContext};
+/// use context_logger::{ContextLogger, LogContext, LogScope};
 ///
 /// // Create a logger.
 /// let env_logger = env_logger::builder().build();
@@ -66,11 +66,11 @@ mod value;
 ///
 /// // Create a context with properties
 /// let ctx = LogContext::new()
-///     .record("request_id", "req-123")
-///     .record("user_id", 42);
+///     .with_record("request_id", "req-123")
+///     .with_record("user_id", 42);
 ///
 /// // Use the context while logging
-/// let _guard = ctx.enter();
+/// let _guard = LogScope::enter(ctx);
 /// info!("Processing request"); // Will include request_id and user_id records
 /// ```
 ///
@@ -136,7 +136,7 @@ impl ContextLogger {
     ///
     /// ```
     /// use log::{info, LevelFilter};
-    /// use context_logger::{ContextLogger, LogContext};
+    /// use context_logger::{ContextLogger, LogContext, LogScope};
     ///
     /// // Create a logger with default records
     /// let logger = ContextLogger::new(env_logger::builder().build())
@@ -145,9 +145,8 @@ impl ContextLogger {
     /// // Initialize it
     /// logger.init(LevelFilter::Info);
     /// // Context records are added after default records
-    /// let _guard = LogContext::new()
-    ///     .record("request_id", "123")
-    ///     .enter();
+    /// let _guard = LogScope::enter(LogContext::new()
+    ///     .with_record("request_id", "123"));
     ///
     /// info!("Processing request"); // Will include service="api", version="1.0.0", request_id="123"
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,7 @@
 
 use std::borrow::Cow;
 
-pub use self::{
-    context::LogContext,
-    future::FutureExt,
-    scope::{LogScope, LogScopeGuard},
-    value::LogValue,
-};
+pub use self::{context::LogContext, future::FutureExt, scope::LogScope, value::LogValue};
 use crate::{record::LogRecord, stack::SCOPE_STACK};
 
 mod context;
@@ -48,7 +43,7 @@ mod value;
 ///
 /// `ContextLogger` wraps an existing logging implementation and adds additional
 /// scope records to log records. These records are taken from the
-/// current scope stack, which is managed by the [`LogContext`] type.
+/// current scope stack, which is managed by [`LogScope`].
 ///
 /// # Example
 ///

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -7,10 +7,10 @@ use crate::{
     stack::{SCOPE_STACK, ScopeStack},
 };
 
-/// A guard representing a current logging context in the context stack.
+/// A guard that represents an active logging context on the current thread's scope stack.
 ///
 /// When the guard is dropped, the context is automatically removed from the stack.
-/// This is returned by the [`LogContext::enter`] method.
+/// Created by [`LogScope::enter`].
 ///
 /// # Examples
 ///
@@ -36,7 +36,10 @@ pub struct LogScope<'a> {
 }
 
 impl LogScope<'_> {
-    /// Activates this scope, returning a guard that will exit the scope when dropped.
+    /// Pushes the given context onto the current thread's scope stack and returns a guard.
+    ///
+    /// The context remains active until the returned guard is dropped, at which point
+    /// it is automatically removed from the stack.
     ///
     /// # In Asynchronous Code
     ///
@@ -108,17 +111,11 @@ impl LogScope<'_> {
         // because we're manually managing the context stack here.
         std::mem::forget(self);
 
-        let frame = SCOPE_STACK.with(ScopeStack::pop).expect(
-            "bug in LogContextGuard::exit: expected a scope frame to exist when popping on exit",
-        );
+        let frame = SCOPE_STACK
+            .with(ScopeStack::pop)
+            .expect("bug in LogScope::exit: expected a scope frame to exist when popping on exit");
         LogContext { frame }
     }
-}
-
-#[derive(Debug)]
-pub struct LogScopeGuard<'a> {
-    // Make this guard unsendable.
-    _marker: PhantomData<&'a *mut ()>,
 }
 
 impl Drop for LogScope<'_> {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -7,11 +7,35 @@ use crate::{
     stack::{SCOPE_STACK, ScopeStack},
 };
 
+/// A guard representing a current logging context in the context stack.
+///
+/// When the guard is dropped, the context is automatically removed from the stack.
+/// This is returned by the [`LogContext::enter`] method.
+///
+/// # Examples
+///
+/// ```
+/// use context_logger::LogContext;
+///
+/// // Create a context with some data
+/// let context = LogContext::new().record("user_id", 123);
+///
+/// // Enter the context (pushes to stack)
+/// let guard = context.enter();
+///
+/// // Log operations here will have access to the context
+/// // ...
+///
+/// // When `guard` goes out of scope, the context is automatically removed
+/// ```
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct LogScope {}
+pub struct LogScope<'a> {
+    // Make this guard unsendable.
+    _marker: PhantomData<&'a *mut ()>,
+}
 
-impl LogScope {
+impl LogScope<'_> {
     /// Activates this scope, returning a guard that will exit the scope when dropped.
     ///
     /// # In Asynchronous Code
@@ -37,8 +61,11 @@ impl LogScope {
     ///
     /// Please use the [`crate::FutureExt::in_log_context`] instead.
     #[must_use]
-    pub fn enter<'a>(context: LogContext) -> LogScopeGuard<'a> {
-        LogScopeGuard::enter(context)
+    pub fn enter(context: LogContext) -> Self {
+        SCOPE_STACK.with(|stack| stack.push(context.frame));
+        Self {
+            _marker: PhantomData,
+        }
     }
 
     /// Adds a record to the currently active scope.
@@ -76,42 +103,6 @@ impl LogScope {
             }
         });
     }
-}
-
-/// A guard representing a current logging context in the context stack.
-///
-/// When the guard is dropped, the context is automatically removed from the stack.
-/// This is returned by the [`LogContext::enter`] method.
-///
-/// # Examples
-///
-/// ```
-/// use context_logger::LogContext;
-///
-/// // Create a context with some data
-/// let context = LogContext::new().record("user_id", 123);
-///
-/// // Enter the context (pushes to stack)
-/// let guard = context.enter();
-///
-/// // Log operations here will have access to the context
-/// // ...
-///
-/// // When `guard` goes out of scope, the context is automatically removed
-/// ```
-#[derive(Debug)]
-pub struct LogScopeGuard<'a> {
-    // Make this guard unsendable.
-    _marker: PhantomData<&'a *mut ()>,
-}
-
-impl LogScopeGuard<'_> {
-    pub(crate) fn enter(context: LogContext) -> Self {
-        SCOPE_STACK.with(|stack| stack.push(context.frame));
-        Self {
-            _marker: PhantomData,
-        }
-    }
 
     pub(crate) fn exit(self) -> LogContext {
         // We need to prevent the destructor from being called
@@ -125,7 +116,13 @@ impl LogScopeGuard<'_> {
     }
 }
 
-impl Drop for LogScopeGuard<'_> {
+#[derive(Debug)]
+pub struct LogScopeGuard<'a> {
+    // Make this guard unsendable.
+    _marker: PhantomData<&'a *mut ()>,
+}
+
+impl Drop for LogScope<'_> {
     fn drop(&mut self) {
         SCOPE_STACK.with(ScopeStack::pop);
     }
@@ -140,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_log_context_guard_enter() {
-        let context = LogContext::new().record("simple", 42);
+        let context = LogContext::new().with_record("simple", 42);
         // Make sure the context stack is empty before entering the context.
         assert_eq!(SCOPE_STACK.with(ScopeStack::is_empty), true);
 
@@ -158,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_log_context_nested_guards() {
-        let outer_context = LogContext::new().record("simple_record", "outer_value");
+        let outer_context = LogContext::new().with_record("simple_record", "outer_value");
         assert_eq!(SCOPE_STACK.with(ScopeStack::len), 0);
 
         let outer_guard = LogScope::enter(outer_context);
@@ -175,7 +172,7 @@ mod tests {
             );
         });
 
-        let inner_context = LogContext::new().record("simple_record", "inner_value");
+        let inner_context = LogContext::new().with_record("simple_record", "inner_value");
         {
             let inner_guard = LogScope::enter(inner_context);
             // Test log context after inner guard is entered.
@@ -209,11 +206,11 @@ mod tests {
 
     #[test]
     fn test_log_context_multithread() {
-        let local_context = LogContext::new().record("simple_record", "main");
+        let local_context = LogContext::new().with_record("simple_record", "main");
         let local_guard = LogScope::enter(local_context);
 
         let first_thread_handle = std::thread::spawn(|| {
-            let inner_context = LogContext::new().record("simple_record", "first_thread");
+            let inner_context = LogContext::new().with_record("simple_record", "first_thread");
             let inner_guard = LogScope::enter(inner_context);
 
             // Test log context after inner guard is entered.
@@ -229,7 +226,7 @@ mod tests {
             drop(inner_guard);
         });
         let second_thread_handle = std::thread::spawn(|| {
-            let inner_context = LogContext::new().record("simple_record", "second_thread");
+            let inner_context = LogContext::new().with_record("simple_record", "second_thread");
             let inner_guard = LogScope::enter(inner_context);
 
             // Test log context after inner guard is entered.

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,11 +1,82 @@
 //! A current logging context guard.
 
-use std::marker::PhantomData;
+use std::{borrow::Cow, marker::PhantomData};
 
 use crate::{
-    LogContext,
+    LogContext, LogValue,
     stack::{SCOPE_STACK, ScopeStack},
 };
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct LogScope {}
+
+impl LogScope {
+    /// Activates this scope, returning a guard that will exit the scope when dropped.
+    ///
+    /// # In Asynchronous Code
+    ///
+    /// *Warning:* in asynchronous code [`Self::enter`] should be used very carefully or avoided entirely.
+    /// Holding the drop guard across `.await` points will result in incorrect logs:
+    ///
+    /// ```rust
+    /// use context_logger::LogContext;
+    ///
+    /// async fn my_async_fn() {
+    ///     let ctx = LogContext::new()
+    ///         .record("request_id", "req-123")
+    ///         .record("user_id", 42);
+    ///     // WARNING: This context will remain active until this
+    ///     // guard is dropped...
+    ///     let _guard = ctx.enter();
+    ///     // But this code causing the runtime to switch to another task,
+    ///     // while remaining in this context.
+    ///     tokio::task::yield_now().await;
+    ///     }
+    /// ```
+    ///
+    /// Please use the [`crate::FutureExt::in_log_context`] instead.
+    #[must_use]
+    pub fn enter<'a>(context: LogContext) -> LogScopeGuard<'a> {
+        LogScopeGuard::enter(context)
+    }
+
+    /// Adds a record to the currently active scope.
+    ///
+    /// This is useful for adding records dynamically without having
+    /// direct access to the current scope.
+    ///
+    /// # Note
+    ///
+    /// If there is no active context, this operation will have no effect.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use context_logger::{LogContext, LogValue};
+    /// use log::info;
+    ///
+    /// fn process_request() {
+    ///     // Add a record to the current scope dynamically
+    ///     LogContext::add_record("processing_time_ms", 42);
+    ///     info!("Request processed");
+    /// }
+    ///
+    /// let _guard = LogContext::new()
+    ///     .record("request_id", "req-123")
+    ///     .enter();
+    ///
+    /// process_request(); // Will log with both request_id and processing_time_ms
+    /// ```
+    pub fn add_record(key: impl Into<Cow<'static, str>>, value: impl Into<LogValue>) {
+        SCOPE_STACK.with(|stack| {
+            if let Some(mut top) = stack.top_mut() {
+                let record = (key.into(), value.into());
+                top.push(record);
+            }
+        });
+    }
+}
 
 /// A guard representing a current logging context in the context stack.
 ///
@@ -28,14 +99,13 @@ use crate::{
 ///
 /// // When `guard` goes out of scope, the context is automatically removed
 /// ```
-#[non_exhaustive]
 #[derive(Debug)]
-pub struct LogContextGuard<'a> {
+pub struct LogScopeGuard<'a> {
     // Make this guard unsendable.
     _marker: PhantomData<&'a *mut ()>,
 }
 
-impl LogContextGuard<'_> {
+impl LogScopeGuard<'_> {
     pub(crate) fn enter(context: LogContext) -> Self {
         SCOPE_STACK.with(|stack| stack.push(context.frame));
         Self {
@@ -55,7 +125,7 @@ impl LogContextGuard<'_> {
     }
 }
 
-impl Drop for LogContextGuard<'_> {
+impl Drop for LogScopeGuard<'_> {
     fn drop(&mut self) {
         SCOPE_STACK.with(ScopeStack::pop);
     }
@@ -74,7 +144,7 @@ mod tests {
         // Make sure the context stack is empty before entering the context.
         assert_eq!(SCOPE_STACK.with(ScopeStack::is_empty), true);
 
-        let guard = context.enter();
+        let guard = LogScope::enter(context);
         // Check that the record was added to the top context.
         assert_eq!(
             SCOPE_STACK.with(|stack| stack.top().unwrap().records().len()),
@@ -91,7 +161,7 @@ mod tests {
         let outer_context = LogContext::new().record("simple_record", "outer_value");
         assert_eq!(SCOPE_STACK.with(ScopeStack::len), 0);
 
-        let outer_guard = outer_context.enter();
+        let outer_guard = LogScope::enter(outer_context);
         assert_eq!(
             SCOPE_STACK.with(|stack| stack.top().unwrap().records().len()),
             1
@@ -107,7 +177,7 @@ mod tests {
 
         let inner_context = LogContext::new().record("simple_record", "inner_value");
         {
-            let inner_guard = inner_context.enter();
+            let inner_guard = LogScope::enter(inner_context);
             // Test log context after inner guard is entered.
             assert_eq!(SCOPE_STACK.with(ScopeStack::len), 2);
             SCOPE_STACK.with(|stack| {
@@ -140,11 +210,11 @@ mod tests {
     #[test]
     fn test_log_context_multithread() {
         let local_context = LogContext::new().record("simple_record", "main");
-        let local_guard = local_context.enter();
+        let local_guard = LogScope::enter(local_context);
 
         let first_thread_handle = std::thread::spawn(|| {
             let inner_context = LogContext::new().record("simple_record", "first_thread");
-            let inner_guard = inner_context.enter();
+            let inner_guard = LogScope::enter(inner_context);
 
             // Test log context after inner guard is entered.
             assert_eq!(SCOPE_STACK.with(ScopeStack::len), 1);
@@ -160,7 +230,8 @@ mod tests {
         });
         let second_thread_handle = std::thread::spawn(|| {
             let inner_context = LogContext::new().record("simple_record", "second_thread");
-            let inner_guard = inner_context.enter();
+            let inner_guard = LogScope::enter(inner_context);
+
             // Test log context after inner guard is entered.
             assert_eq!(SCOPE_STACK.with(ScopeStack::len), 1);
             SCOPE_STACK.with(|stack| {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -30,12 +30,13 @@ use crate::{
 /// ```
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct LogScope<'a> {
-    // Make this guard unsendable.
-    _marker: PhantomData<&'a *mut ()>,
+pub struct LogScope {
+    // Make this guard non-Send: LogScope manages thread-local state
+    // and must not be transferred to another thread.
+    _marker: PhantomData<*mut ()>,
 }
 
-impl LogScope<'_> {
+impl LogScope {
     /// Pushes the given context onto the current thread's scope stack and returns a guard.
     ///
     /// The context remains active until the returned guard is dropped, at which point
@@ -118,7 +119,7 @@ impl LogScope<'_> {
     }
 }
 
-impl Drop for LogScope<'_> {
+impl Drop for LogScope {
     fn drop(&mut self) {
         SCOPE_STACK.with(ScopeStack::pop);
     }
@@ -127,9 +128,13 @@ impl Drop for LogScope<'_> {
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use static_assertions::assert_not_impl_any;
 
     use super::*;
     use crate::stack::SCOPE_STACK;
+
+    // LogScope manages thread-local state and must never be Send.
+    assert_not_impl_any!(LogScope: Send);
 
     #[test]
     fn test_log_context_guard_enter() {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -15,13 +15,13 @@ use crate::{
 /// # Examples
 ///
 /// ```
-/// use context_logger::LogContext;
+/// use context_logger::{LogContext, LogScope};
 ///
 /// // Create a context with some data
-/// let context = LogContext::new().record("user_id", 123);
+/// let context = LogContext::new().with_record("user_id", 123);
 ///
 /// // Enter the context (pushes to stack)
-/// let guard = context.enter();
+/// let guard = LogScope::enter(context);
 ///
 /// // Log operations here will have access to the context
 /// // ...
@@ -44,19 +44,19 @@ impl LogScope<'_> {
     /// Holding the drop guard across `.await` points will result in incorrect logs:
     ///
     /// ```rust
-    /// use context_logger::LogContext;
+    /// use context_logger::{LogContext, LogScope};
     ///
     /// async fn my_async_fn() {
     ///     let ctx = LogContext::new()
-    ///         .record("request_id", "req-123")
-    ///         .record("user_id", 42);
+    ///         .with_record("request_id", "req-123")
+    ///         .with_record("user_id", 42);
     ///     // WARNING: This context will remain active until this
     ///     // guard is dropped...
-    ///     let _guard = ctx.enter();
+    ///     let _guard = LogScope::enter(ctx);
     ///     // But this code causing the runtime to switch to another task,
     ///     // while remaining in this context.
     ///     tokio::task::yield_now().await;
-    ///     }
+    /// }
     /// ```
     ///
     /// Please use the [`crate::FutureExt::in_log_context`] instead.
@@ -80,18 +80,17 @@ impl LogScope<'_> {
     /// # Examples
     ///
     /// ```
-    /// use context_logger::{LogContext, LogValue};
+    /// use context_logger::{LogContext, LogScope};
     /// use log::info;
     ///
     /// fn process_request() {
     ///     // Add a record to the current scope dynamically
-    ///     LogContext::add_record("processing_time_ms", 42);
+    ///     LogScope::add_record("processing_time_ms", 42);
     ///     info!("Request processed");
     /// }
     ///
-    /// let _guard = LogContext::new()
-    ///     .record("request_id", "req-123")
-    ///     .enter();
+    /// let _guard = LogScope::enter(LogContext::new()
+    ///     .with_record("request_id", "req-123"));
     ///
     /// process_request(); // Will log with both request_id and processing_time_ms
     /// ```

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -24,7 +24,7 @@ pub struct ScopeFrame {
     local: Vec<LogRecord>,
 }
 
-/// A stack of scope frames, one per active [`crate::LogContextGuard`].
+/// A stack of scope frames, one per active [`crate::LogScope`].
 #[derive(Debug)]
 pub struct ScopeStack {
     inner: RefCell<Vec<ScopeFrame>>,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -12,6 +12,6 @@ fn test_smoke() {
         Ok(())
     });
 
-    let _guard = LogScope::enter(LogContext::new().record("answer", 42));
+    let _guard = LogScope::enter(LogContext::new().with_record("answer", 42));
     log::info!("Smoke on the water, fire in the sky");
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,3 +1,5 @@
+use context_logger::{LogContext, LogScope};
+
 use crate::common::{RecordExt, check_logger_once};
 
 pub mod common;
@@ -10,8 +12,6 @@ fn test_smoke() {
         Ok(())
     });
 
-    let _guard = context_logger::LogContext::new()
-        .record("answer", 42)
-        .enter();
+    let _guard = LogScope::enter(LogContext::new().record("answer", 42));
     log::info!("Smoke on the water, fire in the sky");
 }


### PR DESCRIPTION
This MR takes away extra functionality from ContextValue into the new LogScope entity, which replaces the LogContextGuard.