### PR TITLE
feat: add computed default records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Introduced a new method `ContextLogger::with_default_record_fn` that allows
+  injecting custom default records based on log record metadata, enabling more
+  flexible and dynamic logging contexts.
 - _breaking_ Introduced inherited context records
   - `LogContext` now stores two separate sets of records (`local` and
     `inherited`), each with its own propagation semantics:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,10 +71,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -74,10 +95,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "colorchoice"
@@ -87,8 +131,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "context-logger"
-version = "0.2.0-pre.2"
+version = "0.2.0-pre.3"
 dependencies = [
+ "chrono",
  "env_logger",
  "erased-serde",
  "futures-util",
@@ -102,6 +147,12 @@ dependencies = [
  "structured-logger",
  "tokio",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "diff"
@@ -150,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +240,30 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -253,6 +334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +397,21 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -454,6 +561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +629,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "slab"
@@ -715,10 +834,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [
 ]
 categories = ["asynchronous", "development-tools::debugging"]
 
-version = "0.2.0-pre.2"
+version = "0.2.0-pre.3"
 edition = "2024"
 rust-version = "1.85"
 
@@ -25,6 +25,7 @@ pin-project = "1"
 serde = "1"
 
 [dev-dependencies]
+chrono = "0.4"
 env_logger = { version = "0.11", features = ["kv"] }
 futures-util = "0.3"
 pretty_assertions = "1.4"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fn main() {
     // Wrap it with ContextLogger to enable context propagation.
     let context_logger = ContextLogger::new(env_logger)
         // Add version default record.
-        .default_record("version", "1.0.0");
+        .with_default_record("version", "1.0.0");
     // Initialize the resulting logger.
     context_logger.init(max_level);
     // Create a context.

--- a/examples/current_context.rs
+++ b/examples/current_context.rs
@@ -9,7 +9,7 @@ fn try_init_logger() -> Result<(), Box<dyn std::error::Error>> {
         .with_target_writer("*", structured_logger::json::new_writer(std::io::stdout()))
         .build();
     ContextLogger::new(logger)
-        .default_record("instance", "contexted_log_async")
+        .with_default_record("instance", "contexted_log_async")
         .try_init(level)?;
 
     Ok(())

--- a/examples/log_async.rs
+++ b/examples/log_async.rs
@@ -16,7 +16,7 @@ fn try_init_logger() -> Result<(), Box<dyn std::error::Error>> {
         .with_target_writer("*", structured_logger::json::new_writer(std::io::stdout()))
         .build();
     ContextLogger::new(logger)
-        .default_record("instance", "contexted_log_async")
+        .with_default_record("instance", "contexted_log_async")
         .try_init(level)?;
 
     Ok(())

--- a/examples/log_sync.rs
+++ b/examples/log_sync.rs
@@ -14,7 +14,7 @@ fn try_init_logger() -> Result<(), Box<dyn std::error::Error>> {
     let level = env_logger.filter();
 
     ContextLogger::new(env_logger)
-        .default_record("instance", "contexted_log_sync")
+        .with_default_record("instance", "contexted_log_sync")
         .try_init(level)?;
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ mod records;
 mod scope;
 mod value;
 
+type LogRecordsFn = Box<dyn Fn(&log::Record) -> LogRecords + Send + Sync>;
+
 pub use self::{
     context::LogContext,
     future::FutureExt,
@@ -77,8 +79,9 @@ pub use self::{
 ///
 /// See [`LogContext`] for more information on how to create and manage scope records.
 pub struct ContextLogger {
-    records: LogRecords,
     inner: Box<dyn log::Log>,
+    default_records: LogRecords,
+    default_records_fn: Option<LogRecordsFn>,
 }
 
 impl ContextLogger {
@@ -91,8 +94,9 @@ impl ContextLogger {
         L: log::Log + 'static,
     {
         Self {
-            records: LogRecords::new(),
             inner: Box::new(inner),
+            default_records: LogRecords::new(),
+            default_records_fn: None,
         }
     }
 
@@ -141,8 +145,8 @@ impl ContextLogger {
     ///
     /// // Create a logger with default records
     /// let logger = ContextLogger::new(env_logger::builder().build())
-    ///     .default_record("service", "api")
-    ///     .default_record("version", "1.0.0");
+    ///     .with_default_record("service", "api")
+    ///     .with_default_record("version", "1.0.0");
     /// // Initialize it
     /// logger.init(LevelFilter::Info);
     /// // Context records are added after default records
@@ -152,13 +156,21 @@ impl ContextLogger {
     /// info!("Processing request"); // Will include service="api", version="1.0.0", request_id="123"
     /// ```
     #[must_use]
-    pub fn default_record(
+    pub fn with_default_record(
         mut self,
         key: impl Into<Cow<'static, str>>,
         value: impl Into<LogValue>,
     ) -> Self {
-        self.records.insert(key, value);
+        self.default_records.insert(key, value);
         self
+    }
+
+    #[must_use]
+    pub fn with_default_records_fn<F>(mut self, f: F)
+    where
+        F: Fn(&log::Record) -> LogRecords + Send + Sync + 'static,
+    {
+        self.default_records_fn = Some(Box::new(f));
     }
 }
 
@@ -174,7 +186,20 @@ impl log::Log for ContextLogger {
     }
 
     fn log(&self, record: &log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
         let error = scope::stack::SCOPE_STACK.try_with(|stack| {
+            // LogRecords::default() does not allocate memory, so we can use it directly
+            // to simplify the logic without overhead.
+            let extra_default_records = self
+                .default_records_fn
+                .as_ref()
+                .map(|f| f(record))
+                .unwrap_or_default();
+            let default_records = self.default_records.iter().chain(&extra_default_records);
+
             // Only the top frame is read here intentionally: inherited records from
             // outer scopes are copied into each newly entered frame on `enter()`,
             // so the top frame always contains a complete, flat view of active records.
@@ -184,7 +209,7 @@ impl log::Log for ContextLogger {
                         .to_builder()
                         .key_values(&SourceWithRecords {
                             source: &record.key_values(),
-                            records: self.records.iter().chain(top.records()),
+                            records: default_records.chain(top.records()),
                         })
                         .build(),
                 );
@@ -194,7 +219,7 @@ impl log::Log for ContextLogger {
                         .to_builder()
                         .key_values(&SourceWithRecords {
                             source: &record.key_values(),
-                            records: self.records.iter(),
+                            records: default_records,
                         })
                         .build(),
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,8 +165,32 @@ impl ContextLogger {
         self
     }
 
+    /// Adds a dynamic default record computed by the given closure for each log entry.
+    ///
+    /// Like [`Self::with_default_record`], the record is included in all log entries.
+    /// However, unlike the static variant, the value is *computed at log time* by invoking the
+    /// provided closure with the current [`log::Record`]. This makes it suitable for fields
+    /// whose values are not known upfront, such as timestamps or thread IDs.
+    ///
+    /// # Example
+    ///
+    /// Adding a current timestamp.
+    ///
+    /// ```
+    /// use chrono::Utc;
+    /// use log::{info, LevelFilter};
+    /// use context_logger::{ContextLogger, LogValue};
+    ///
+    /// let logger = ContextLogger::new(env_logger::builder().build())
+    ///         .with_default_record_fn("timestamp", |_record| {
+    ///          LogValue::from(Utc::now().to_rfc3339().to_string())
+    ///         });
+    /// logger.init(LevelFilter::Info);
+    ///
+    /// info!("Hello"); // The "timestamp" field will contain an RFC 3339 timestamp
+    /// ```
     #[must_use]
-    pub fn with_default_record_fn<F>(
+    pub fn with_default_record_fn(
         mut self,
         key: impl Into<Cow<'static, str>>,
         f: impl Fn(&log::Record) -> LogValue + Send + Sync + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@ pub use self::{
 /// See [`LogContext`] for more information on how to create and manage scope records.
 pub struct ContextLogger {
     inner: Box<dyn log::Log>,
-    records: LogRecords,
-    dynamic_records: HashMap<Cow<'static, str>, LogValueFn>,
+    default_records: LogRecords,
+    dynamic_default_records: HashMap<Cow<'static, str>, LogValueFn>,
 }
 
 impl ContextLogger {
@@ -95,8 +95,8 @@ impl ContextLogger {
     {
         Self {
             inner: Box::new(inner),
-            records: LogRecords::new(),
-            dynamic_records: HashMap::new(),
+            default_records: LogRecords::new(),
+            dynamic_default_records: HashMap::new(),
         }
     }
 
@@ -161,7 +161,7 @@ impl ContextLogger {
         key: impl Into<Cow<'static, str>>,
         value: impl Into<LogValue>,
     ) -> Self {
-        self.records.insert(key, value);
+        self.default_records.insert(key, value);
         self
     }
 
@@ -171,6 +171,8 @@ impl ContextLogger {
     /// However, unlike the static variant, the value is *computed at log time* by invoking the
     /// provided closure with the current [`log::Record`]. This makes it suitable for fields
     /// whose values are not known upfront, such as timestamps or thread IDs.
+    ///
+    /// **Note!** *The order in which dynamic default record functions are evaluated is not guaranteed.*
     ///
     /// # Example
     ///
@@ -183,19 +185,20 @@ impl ContextLogger {
     ///
     /// let logger = ContextLogger::new(env_logger::builder().build())
     ///         .with_default_record_fn("timestamp", |_record| {
-    ///          LogValue::from(Utc::now().to_rfc3339().to_string())
+    ///          Utc::now().to_rfc3339().to_string()
     ///         });
     /// logger.init(LevelFilter::Info);
     ///
     /// info!("Hello"); // The "timestamp" field will contain an RFC 3339 timestamp
     /// ```
     #[must_use]
-    pub fn with_default_record_fn(
+    pub fn with_default_record_fn<V: Into<LogValue>>(
         mut self,
         key: impl Into<Cow<'static, str>>,
-        f: impl Fn(&log::Record) -> LogValue + Send + Sync + 'static,
+        f: impl Fn(&log::Record) -> V + Send + Sync + 'static,
     ) -> Self {
-        self.dynamic_records.insert(key.into(), Box::new(f));
+        self.dynamic_default_records
+            .insert(key.into(), Box::new(move |record| f(record).into()));
         self
     }
 }
@@ -217,15 +220,15 @@ impl log::Log for ContextLogger {
         }
 
         let error = scope::stack::SCOPE_STACK.try_with(|stack| {
-            let dynamic_records = self
-                .dynamic_records
+            let dynamic_default_records = self
+                .dynamic_default_records
                 .iter()
                 .map(|(key, f)| (key, f(record)))
                 .collect::<Vec<_>>();
             let default_records = self
-                .records
+                .default_records
                 .iter()
-                .chain(dynamic_records.iter().map(|(k, v)| (*k, v)));
+                .chain(dynamic_default_records.iter().map(|(k, v)| (*k, v)));
 
             // Only the top frame is read here intentionally: inherited records from
             // outer scopes are copied into each newly entered frame on `enter()`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! [`env_logger`]: https://docs.rs/env_logger/latest/env_logger
 //! [`log4rs`]: https://docs.rs/log4rs/latest/log4rs
 
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 use crate::records::LogRecordRef;
 
@@ -37,7 +37,7 @@ mod records;
 mod scope;
 mod value;
 
-type LogRecordsFn = Box<dyn Fn(&log::Record) -> LogRecords + Send + Sync>;
+type LogValueFn = Box<dyn Fn(&log::Record) -> LogValue + Send + Sync>;
 
 pub use self::{
     context::LogContext,
@@ -80,8 +80,8 @@ pub use self::{
 /// See [`LogContext`] for more information on how to create and manage scope records.
 pub struct ContextLogger {
     inner: Box<dyn log::Log>,
-    default_records: LogRecords,
-    default_records_fn: Option<LogRecordsFn>,
+    records: LogRecords,
+    dynamic_records: HashMap<Cow<'static, str>, LogValueFn>,
 }
 
 impl ContextLogger {
@@ -95,8 +95,8 @@ impl ContextLogger {
     {
         Self {
             inner: Box::new(inner),
-            default_records: LogRecords::new(),
-            default_records_fn: None,
+            records: LogRecords::new(),
+            dynamic_records: HashMap::new(),
         }
     }
 
@@ -161,16 +161,18 @@ impl ContextLogger {
         key: impl Into<Cow<'static, str>>,
         value: impl Into<LogValue>,
     ) -> Self {
-        self.default_records.insert(key, value);
+        self.records.insert(key, value);
         self
     }
 
     #[must_use]
-    pub fn with_default_records_fn<F>(mut self, f: F)
-    where
-        F: Fn(&log::Record) -> LogRecords + Send + Sync + 'static,
-    {
-        self.default_records_fn = Some(Box::new(f));
+    pub fn with_default_record_fn<F>(
+        mut self,
+        key: impl Into<Cow<'static, str>>,
+        f: impl Fn(&log::Record) -> LogValue + Send + Sync + 'static,
+    ) -> Self {
+        self.dynamic_records.insert(key.into(), Box::new(f));
+        self
     }
 }
 
@@ -191,14 +193,15 @@ impl log::Log for ContextLogger {
         }
 
         let error = scope::stack::SCOPE_STACK.try_with(|stack| {
-            // LogRecords::default() does not allocate memory, so we can use it directly
-            // to simplify the logic without overhead.
-            let extra_default_records = self
-                .default_records_fn
-                .as_ref()
-                .map(|f| f(record))
-                .unwrap_or_default();
-            let default_records = self.default_records.iter().chain(&extra_default_records);
+            let dynamic_records = self
+                .dynamic_records
+                .iter()
+                .map(|(key, f)| (key, f(record)))
+                .collect::<Vec<_>>();
+            let default_records = self
+                .records
+                .iter()
+                .chain(dynamic_records.iter().map(|(k, v)| (*k, v)));
 
             // Only the top frame is read here intentionally: inherited records from
             // outer scopes are copied into each newly entered frame on `enter()`,

--- a/src/records.rs
+++ b/src/records.rs
@@ -53,7 +53,7 @@ impl LogRecords {
     /// Inserts a key-value record into this collection.
     ///
     /// Unlike [`with_record`](LogRecords::with_record), this method borrows `self` and
-    /// returns a mutable reference, allowing it to be used when chaining with other methodsё
+    /// returns a mutable reference, allowing it to be used when chaining with other methods
     /// that require borrowing.
     ///
     /// # Examples

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,16 +13,17 @@ impl RecordExt for Record<'_> {
     }
 }
 
-pub fn check_logger_once<F>(check: F)
+pub fn check_logger_once<I, F>(init: I, check: F)
 where
+    I: FnOnce(ContextLogger) -> ContextLogger,
     F: Fn(&Record) -> std::io::Result<()> + Send + Sync + 'static,
 {
     let level_filter = LevelFilter::Trace;
-    let logger = ContextLogger::new(
+    let logger = init(ContextLogger::new(
         env_logger::Builder::new()
             .filter_level(level_filter)
             .format(move |_fmt, record| check(record))
             .build(),
-    );
+    ));
     logger.init(level_filter);
 }

--- a/tests/default_records.rs
+++ b/tests/default_records.rs
@@ -1,0 +1,31 @@
+// Warning: Because each test initializes the logger, we need to split the
+// tests into separate files to avoid multiple initializations of the logger.
+
+use context_logger::LogValue;
+use pretty_assertions::assert_eq;
+
+use crate::common::{RecordExt, check_logger_once};
+
+pub mod common;
+
+#[test]
+fn test_default() {
+    check_logger_once(
+        |logger| {
+            logger
+                .with_default_record("tag", 42)
+                .with_default_record_fn("my_log_level", |log_record| log_record.level().to_string())
+                .with_default_record_fn("thread_name", |_| {
+                    LogValue::serde(std::thread::current().name().map(ToOwned::to_owned))
+                })
+        },
+        |entry| {
+            assert_eq!(entry.get_record("tag").unwrap(), 42);
+            assert_eq!(entry.get_record("my_log_level").unwrap(), "INFO");
+            assert_eq!(entry.get_record("thread_name").unwrap(), "test_default");
+            Ok(())
+        },
+    );
+
+    log::info!("Wazzup everyone!");
+}

--- a/tests/shadowing.rs
+++ b/tests/shadowing.rs
@@ -9,13 +9,16 @@ pub mod common;
 
 #[test]
 fn test_inherited_records_shadowing() {
-    check_logger_once(|entry| {
-        assert_eq!(entry.get_record("answer").unwrap(), 42);
-        assert_eq!(entry.get_record("name").unwrap(), "Robin");
-        assert_eq!(entry.get_record("shadow").unwrap(), true);
-        assert_eq!(entry.get_record("inherited_shadow").unwrap(), "child");
-        Ok(())
-    });
+    check_logger_once(
+        |logger| logger,
+        |entry| {
+            assert_eq!(entry.get_record("answer").unwrap(), 42);
+            assert_eq!(entry.get_record("name").unwrap(), "Robin");
+            assert_eq!(entry.get_record("shadow").unwrap(), true);
+            assert_eq!(entry.get_record("inherited_shadow").unwrap(), "child");
+            Ok(())
+        },
+    );
 
     LogContext::new()
         .with_inherited_record("answer", 42)

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -9,11 +9,14 @@ pub mod common;
 
 #[test]
 fn test_smoke() {
-    check_logger_once(|entry| {
-        let val = entry.get_record("answer").unwrap();
-        assert_eq!(val, 42);
-        Ok(())
-    });
+    check_logger_once(
+        |logger| logger,
+        |entry| {
+            let val = entry.get_record("answer").unwrap();
+            assert_eq!(val, 42);
+            Ok(())
+        },
+    );
 
     let _guard = LogScope::enter(LogContext::new().with_local_record("answer", 42));
     log::info!("Smoke on the water, fire in the sky");


### PR DESCRIPTION
This MR introduces a new method `ContextLogger::with_default_record_fn` that allows injecting custom default records based on log record metadata, enabling more flexible and dynamic logging contexts.

Closes #31 